### PR TITLE
redundant span class bmlt_admin_value_left

### DIFF
--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -1787,7 +1787,7 @@ class c_comdef_admin_main_console
                         }
                     else
                         {
-                        $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_state_text_input" type="text" value="'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_state_prompt'] ).'" /></span>';
+                        $ret .= '<input id="bmlt_admin_single_meeting_editor_template_meeting_state_text_input" type="text" value="'.htmlspecialchars ( $this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_state_prompt'] ).'" />';
                         }
                     $ret .= '</span>';
                     $ret .= '<div class="clear_both"></div>';


### PR DESCRIPTION
this causes the input boxes to not line up properly and is redundant. 

![screen shot 2018-12-03 at 4 39 29 pm](https://user-images.githubusercontent.com/34245618/49403214-219dcc00-f71a-11e8-8759-1f69f068c5e7.png)
