### PR TITLE
use case-insensitive sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ For instructions on installing the root server, see [the page on installing a ne
 CHANGELIST
 ----------
 
+***Version 2.12.4* ** *- UNRELEASED*
+- Made sorting case-insensitive, for users and service bodies.
+
 ***Version 2.12.3* ** *- December 7, 2018*
 
 - The service bodies list under the "Search For Meetings Tab" in the "Meeting Editor" is now sorted.

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -1774,7 +1774,7 @@ class c_comdef_admin_main_console
                 $f_array = $this->my_server->GetFormatsArray();
                 $f_array = $f_array[$this->my_server->GetLocalLang()];
                 usort($f_array, function ($a, $b) {
-                    return strcmp($a->GetKey(), $b->GetKey());
+                    return strcasecmp($a->GetKey(), $b->GetKey());
                 });
         foreach ($f_array as $format) {
             if ($format instanceof c_comdef_format) {
@@ -1981,6 +1981,6 @@ class c_comdef_admin_main_console
     public function compare_names($a, $b)
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-        return strcmp($a->GetLocalName(), $b->GetLocalName());
+        return strcasecmp($a->GetLocalName(), $b->GetLocalName());
     }
 }

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -1774,7 +1774,7 @@ class c_comdef_admin_main_console
                 $f_array = $this->my_server->GetFormatsArray();
                 $f_array = $f_array[$this->my_server->GetLocalLang()];
                 usort($f_array, function ($a, $b) {
-                    return strcasecmp($a->GetKey(), $b->GetKey());
+                    return strnatcasecmp($a->GetKey(), $b->GetKey());
                 });
         foreach ($f_array as $format) {
             if ($format instanceof c_comdef_format) {
@@ -1981,6 +1981,6 @@ class c_comdef_admin_main_console
     public function compare_names($a, $b)
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-        return strcasecmp($a->GetLocalName(), $b->GetLocalName());
+        return strnatcasecmp($a->GetLocalName(), $b->GetLocalName());
     }
 }


### PR DESCRIPTION
could use this or [strnatcasecmp](http://php.net/strnatcasecmp)  which uses a [natural sort order](https://github.com/sourcefrog/natsort), [strcasecmp](http://php.net/manual/en/function.strcasecmp.php) is probably fine though. this will sort the users and service bodies in admin case-insensitive.