### PR TITLE
add 'secret' option to not sort formats

### DIFF
--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -1784,7 +1784,7 @@ class c_comdef_admin_main_console
             $ret .= '<div class="format_tab_inner_div">';
                 $f_array = $this->my_server->GetFormatsArray();
                 $f_array = $f_array[$this->my_server->GetLocalLang()];
-        if (!$this->my_localized_strings['do_not_sort_formats']) {
+        if ($this->my_localized_strings['sort_formats']) {
             usort($f_array, function ($a, $b) {
                 return strnatcasecmp($a->GetKey(), $b->GetKey());
             });

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -1784,9 +1784,11 @@ class c_comdef_admin_main_console
             $ret .= '<div class="format_tab_inner_div">';
                 $f_array = $this->my_server->GetFormatsArray();
                 $f_array = $f_array[$this->my_server->GetLocalLang()];
-                usort($f_array, function ($a, $b) {
-                    return strnatcasecmp($a->GetKey(), $b->GetKey());
-                });
+                if (!$this->my_localized_strings['do_not_sort_formats']) {
+                    usort($f_array, function ($a, $b) {
+                        return strnatcasecmp($a->GetKey(), $b->GetKey());
+                    });
+                }
         foreach ($f_array as $format) {
             if ($format instanceof c_comdef_format) {
                 $ret .= '<div class="bmlt_admin_meeting_one_format_div">';

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -1784,11 +1784,11 @@ class c_comdef_admin_main_console
             $ret .= '<div class="format_tab_inner_div">';
                 $f_array = $this->my_server->GetFormatsArray();
                 $f_array = $f_array[$this->my_server->GetLocalLang()];
-                if (!$this->my_localized_strings['do_not_sort_formats']) {
-                    usort($f_array, function ($a, $b) {
-                        return strnatcasecmp($a->GetKey(), $b->GetKey());
-                    });
-                }
+        if (!$this->my_localized_strings['do_not_sort_formats']) {
+            usort($f_array, function ($a, $b) {
+                return strnatcasecmp($a->GetKey(), $b->GetKey());
+            });
+        }
         foreach ($f_array as $format) {
             if ($format instanceof c_comdef_format) {
                 $ret .= '<div class="bmlt_admin_meeting_one_format_div">';

--- a/main_server/server/c_comdef_server.class.php
+++ b/main_server/server/c_comdef_server.class.php
@@ -2671,6 +2671,7 @@ class c_comdef_server
                     c_comdef_server::$server_local_strings['include_service_body_email_in_semantic'] = $g_include_service_body_email_in_semantic;
                 }
 
+                c_comdef_server::$server_local_strings['do_not_sort_formats'] = isset($do_not_sort_formats) ? $do_not_sort_formats : '';
                 c_comdef_server::$server_local_strings['meeting_counties_and_sub_provinces'] = isset($meeting_counties_and_sub_provinces) ? $meeting_counties_and_sub_provinces : array();
                 c_comdef_server::$server_local_strings['meeting_states_and_provinces'] = isset($meeting_states_and_provinces) ? $meeting_states_and_provinces : array();
                 c_comdef_server::$server_local_strings['google_api_key'] = isset($gkey) ? $gkey : '';

--- a/main_server/server/c_comdef_server.class.php
+++ b/main_server/server/c_comdef_server.class.php
@@ -2671,7 +2671,7 @@ class c_comdef_server
                     c_comdef_server::$server_local_strings['include_service_body_email_in_semantic'] = $g_include_service_body_email_in_semantic;
                 }
 
-                c_comdef_server::$server_local_strings['do_not_sort_formats'] = isset($do_not_sort_formats) ? $do_not_sort_formats : '';
+                c_comdef_server::$server_local_strings['do_not_sort_formats'] = isset($do_not_sort_formats) ? $do_not_sort_formats : false;
                 c_comdef_server::$server_local_strings['meeting_counties_and_sub_provinces'] = isset($meeting_counties_and_sub_provinces) ? $meeting_counties_and_sub_provinces : array();
                 c_comdef_server::$server_local_strings['meeting_states_and_provinces'] = isset($meeting_states_and_provinces) ? $meeting_states_and_provinces : array();
                 c_comdef_server::$server_local_strings['google_api_key'] = isset($gkey) ? $gkey : '';

--- a/main_server/server/c_comdef_server.class.php
+++ b/main_server/server/c_comdef_server.class.php
@@ -2671,7 +2671,7 @@ class c_comdef_server
                     c_comdef_server::$server_local_strings['include_service_body_email_in_semantic'] = $g_include_service_body_email_in_semantic;
                 }
 
-                c_comdef_server::$server_local_strings['do_not_sort_formats'] = isset($do_not_sort_formats) ? $do_not_sort_formats : false;
+                c_comdef_server::$server_local_strings['sort_formats'] = isset($sort_formats) ? $sort_formats : true;
                 c_comdef_server::$server_local_strings['meeting_counties_and_sub_provinces'] = isset($meeting_counties_and_sub_provinces) ? $meeting_counties_and_sub_provinces : array();
                 c_comdef_server::$server_local_strings['meeting_states_and_provinces'] = isset($meeting_states_and_provinces) ? $meeting_states_and_provinces : array();
                 c_comdef_server::$server_local_strings['google_api_key'] = isset($gkey) ? $gkey : '';


### PR DESCRIPTION
if `$sort_formats = false;` is set in auto-config the formats won't be sorted.