### PR TITLE
fix for noon meetings not being returned on Admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ CHANGELIST
 - Added meetings by location and day option to bmlt.js.
 - Simple GetFormats response is now sorted.
 - Added $default_minute_interval to override the minute interval for Start Time and Interval on the Admin UI.
+- Fixed issue with Admin UI not returning noon meetings when searching for afternoon meetings.
 
 ***Version 2.12.5* ** *- December 24, 2018*
 - Added user name to sign out link for the administration UI.

--- a/main_server/local_server/server_admin/server_admin_javascript.js
+++ b/main_server/local_server/server_admin/server_admin_javascript.js
@@ -767,7 +767,7 @@ function BMLT_Server_Admin()
             starts_after = new Array(0, 0);
             starts_before = new Array(12, 0);
         } else if ( document.getElementById('bmlt_admin_meeting_search_start_time_aft_checkbox').checked ) {
-            starts_after = new Array(12, 0);
+            starts_after = new Array(11, 59);
             starts_before = new Array(18, 0);
         } else if ( document.getElementById('bmlt_admin_meeting_search_start_time_eve_checkbox').checked ) {
             starts_after = new Array(18, 0);


### PR DESCRIPTION
The Admin UI wasn't returning noon meetings when using the "Search For Meetings" option. this fixes it and meetings will now be returned when the Afternoon radio box is selected.