### PR TITLE
Fix warning that occurred when saving users caused by inconsistent da…

### DIFF
--- a/main_server/server/c_comdef_server.class.php
+++ b/main_server/server/c_comdef_server.class.php
@@ -393,6 +393,9 @@ class c_comdef_server
             $obj_array = array();
             /// Read in all the users, and instantiate an array of objects.
             foreach ($rows as $row) {
+                $time = explode(" ", $row['last_access_datetime']);
+                $t0 = explode("-", $time[0]);
+                $t1 = explode(":", $time[1]);
                 $obj_array[$row['id_bigint']] = new c_comdef_user(
                     $this,
                     $row['id_bigint'],
@@ -404,7 +407,7 @@ class c_comdef_server
                     $row['name_string'],
                     $row['description_string'],
                     $row['owner_id_bigint'],
-                    $row['last_access_datetime']
+                    mktime($t1[0], $t1[1], $t1[2], $t0[1], $t0[2], $t0[0])
                 );
             }
             


### PR DESCRIPTION
…te parsing


Fixes warning [Tue Apr 23 20:06:20.252427 2019] [php7:notice] [pid 29308] [client 174.111.17.210:53139] PHP Notice:  A non well formed numeric value encountered in /var/www/bmlt/main_server/server/classes/c_comdef_user.class.php on line 152, referer: https://bmlt.sezf.org/main_server/

When saving a user, it threw a warning when parsing the time, because the in-memory list of users was not passing in a unix time stamp as expected when calling the constructor.