### PR TITLE
WIP: Add unpublished reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ CHANGELIST
 ***Version 2.13.3* ** *- TBD*
 
 - When saving a change to a meeting, the edit screen for that meeting is no longer closed. This makes it easier for the user to keep their place in the user interface.
+- Added an 'Unpublished Reason' field to the meeting editor UI to allow users to communicate why a meeting is unpublished. This will help NAWS reconcile BMLT lists with their database.
 
 ***Version 2.13.2* ** *- July 4, 2019*
 

--- a/main_server/client_interface/csv/csv.php
+++ b/main_server/client_interface/csv/csv.php
@@ -416,7 +416,7 @@ function parse_redirect(
                 $result2 = array ('"key","description"');
             
                 foreach ($keys as $key) {
-                    if (($key['visibility'] != 1) && ($key['key'] != 'published') && ($key['key'] != 'shared_group_id_bigint')) {
+                    if (($key['visibility'] != 1) && ($key['key'] != 'published') && ($key['key'] != 'unpublished_reason') && ($key['key'] != 'shared_group_id_bigint')) {
                         $result2[] = '"'.$key['key'].'","'.$key['field_prompt'].'"';
                     }
                 }

--- a/main_server/client_interface/csv/search_results_csv.php
+++ b/main_server/client_interface/csv/search_results_csv.php
@@ -466,8 +466,8 @@ function DisplaySearchResultsCSV(
                                                 case 'lang_enum':
                                                 case 'longitude':
                                                 case 'latitude':
-                                                case 'latitude':
                                                 case 'published':
+                                                case 'unpublished_reason':
                                                 case 'email_contact':
                                                 case 'meeting_name':
                                                 case 'location_text':

--- a/main_server/local_server/db_connect.php
+++ b/main_server/local_server/db_connect.php
@@ -167,6 +167,14 @@ function DB_Connect_and_Upgrade()
                 }
             } catch (Exception $e) {
             }
+        }),
+        array(2, function () {
+            $dbPrefix = $GLOBALS['dbPrefix'];
+            $table = "$dbPrefix" . "_comdef_meetings_main";
+            $sql = "ALTER TABLE `$table` ADD `unpublished_reason` VARCHAR(20) NOT NULL DEFAULT '' AFTER `published`";
+            c_comdef_dbsingleton::preparedExec($sql);
+            $sql = "ALTER TABLE `$table` ADD KEY `unpublished_reason` (`unpublished_reason`)";
+            c_comdef_dbsingleton::preparedExec($sql);
         })
     );
 

--- a/main_server/local_server/install_wizard/sql_files/initialMeetingsStructure.sql
+++ b/main_server/local_server/install_wizard/sql_files/initialMeetingsStructure.sql
@@ -11,6 +11,7 @@ CREATE TABLE `%%PREFIX%%_comdef_meetings_main` (
   `longitude` double default NULL,
   `latitude` double default NULL,
   `published` tinyint(4) NOT NULL default '0',
+  `unpublished_reason` varchar(20) NOT NULL DEFAULT '',
   `email_contact` varchar(255) default NULL,
   PRIMARY KEY  (`id_bigint`),
   KEY `weekday_tinyint` (`weekday_tinyint`),
@@ -24,6 +25,7 @@ CREATE TABLE `%%PREFIX%%_comdef_meetings_main` (
   KEY `longitude` (`longitude`),
   KEY `latitude` (`latitude`),
   KEY `published` (`published`),
+  KEY `unpublished_reason` (`unpublished_reason`),
   KEY `email_contact` (`email_contact`)
 ) DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
 CREATE TABLE `%%PREFIX%%_comdef_meetings_data` (

--- a/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -1062,6 +1062,7 @@ class c_comdef_admin_ajax_handler
                             case 'lang_enum':
                             case 'duration_time':
                             case 'formats':
+                            case 'unpublished_reason':
                                 $data[$key] = $value;
                                 break;
                             

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -413,7 +413,7 @@ class c_comdef_admin_main_console
              */
             $ret .= '</script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/json2.js"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
-            $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/server_admin_javascript.js?v='. time() .'"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
+            $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/server_admin_javascript.js"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             $ret .= '<noscript class="main_noscript">'.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['noscript']).'</noscript>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             // Belt and suspenders. Just make sure the user is legit.
         if (($this->my_user instanceof c_comdef_user) && ($this->my_user->GetUserLevel() != _USER_LEVEL_DISABLED)) {
@@ -1577,6 +1577,18 @@ class c_comdef_admin_main_console
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right"><input type="checkbox" id="bmlt_admin_meeting_template_published_checkbox" /></span>';
                     $ret .= '<label class="bmlt_admin_med_label_left" for="bmlt_admin_meeting_template_published_checkbox">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_is_published']).'</label>';
+                    $ret .= '<div class="clear_both"></div>';
+                $ret .= '</div>';
+
+                $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
+                    $ret .= '<span class="bmlt_admin_med_label_right">Unpublished Reason:</span>';
+                    $ret .= '<span class="bmlt_admin_value_left">';
+                        $ret .= '<select id="bmlt_admin_single_meeting_editor_template_unpublished_reason_select">';
+                            $ret .= '<option value="">Unspecified</option>';
+                            $ret .= '<option value="Holiday">Holiday</option>';
+                            $ret .= '<option value="Weather">Weather</option>';
+                        $ret .= '</select>';
+                    $ret .= '</span>';
                     $ret .= '<div class="clear_both"></div>';
                 $ret .= '</div>';
             }

--- a/main_server/local_server/server_admin/c_comdef_admin_xml_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_xml_handler.class.php
@@ -1295,7 +1295,8 @@ class c_comdef_admin_xml_handler
                                     $data =& $meeting_obj->GetMeetingData();
                                     $data[$meeting_field] = $newVals;
                                     break;
-                                
+
+                                case 'unpublished_reason':
                                 case 'worldid_mixed':
                                     $old_value = $meeting_obj->GetMeetingDataValue($meeting_field);
                                     $data =& $meeting_obj->GetMeetingData();

--- a/main_server/local_server/server_admin/server_admin_javascript.js
+++ b/main_server/local_server/server_admin/server_admin_javascript.js
@@ -2070,6 +2070,7 @@ function BMLT_Server_Admin()
         this.setUpOtherTab(meeting_object);
         
         this.setPublished(meeting_object);
+        this.setUnpublishedReason(meeting_object);
         this.handleNewAddressInfo(meeting_id);
         this.setFormatCheckboxHandlers(meeting_object);
     };
@@ -2277,6 +2278,21 @@ function BMLT_Server_Admin()
         published_checkbox.onclick = function () {
             admin_handler_object.reactToPublishedCheck(meeting_id); };
     };
+
+    /************************************************************************************//**
+     *   \brief
+     ****************************************************************************************/
+    this.setUnpublishedReason = function (in_meeting_object) {
+        var meeting_id = in_meeting_object.id_bigint;
+
+        var unpublishedReasonSelect = document.getElementById('bmlt_admin_single_meeting_editor_' + meeting_id + '_unpublished_reason_select');
+        unpublishedReasonSelect.value = in_meeting_object.unpublished_reason ? in_meeting_object.unpublished_reason : "";
+
+        this.reactToUnpublishReasonSelect(meeting_id);
+
+        unpublishedReasonSelect.onchange = function () {
+            admin_handler_object.reactToUnpublishReasonSelect(meeting_id); };
+    };
     
     /************************************************************************************//**
     *   \brief
@@ -2466,9 +2482,31 @@ function BMLT_Server_Admin()
         var the_meeting_object = editor_object.meeting_object;
         
         the_meeting_object.published = published_checkbox.checked ? '1' : '0';
+
+        var unpublishedReasonSelect = document.getElementById('bmlt_admin_single_meeting_editor_' + in_meeting_id + '_unpublished_reason_select');
+        var mainUnpublishedDiv = unpublishedReasonSelect.parentNode.parentNode;
+        if (published_checkbox.checked) {
+            mainUnpublishedDiv.className += ' item_hidden';
+            the_meeting_object.unpublished_reason = "";
+        } else {
+            mainUnpublishedDiv.className = mainUnpublishedDiv.className.replace(" item_hidden", "");
+            the_meeting_object.unpublished_reason = unpublishedReasonSelect.value;
+        }
+
         this.validateMeetingEditorButton(in_meeting_id);
     };
-    
+
+    /************************************************************************************//**
+     *   \brief
+     ****************************************************************************************/
+    this.reactToUnpublishReasonSelect = function (in_meeting_id) {
+        var editor_object = document.getElementById('bmlt_admin_single_meeting_editor_' + in_meeting_id + '_div');
+        var the_meeting_object = editor_object.meeting_object;
+        var unpublishedReasonSelect = document.getElementById('bmlt_admin_single_meeting_editor_' + in_meeting_id + '_unpublished_reason_select');
+        the_meeting_object.unpublished_reason = unpublishedReasonSelect.value;
+        this.validateMeetingEditorButton(in_meeting_id);
+    };
+
     /************************************************************************************//**
     *   \brief
     ****************************************************************************************/

--- a/main_server/local_server/server_admin/server_admin_javascript.js
+++ b/main_server/local_server/server_admin/server_admin_javascript.js
@@ -1219,7 +1219,7 @@ function BMLT_Server_Admin()
             
                         this.m_editing_window_open = null;
                     };
-                        
+
                     display_parent.meeting_editor_object = document.createElement('div');   // Create the container element.
                     display_parent.meeting_editor_object.className = 'bmlt_admin_meeting_search_results_editor_container_div';
                     display_parent.appendChild(display_parent.meeting_editor_object);
@@ -2286,7 +2286,13 @@ function BMLT_Server_Admin()
         var meeting_id = in_meeting_object.id_bigint;
 
         var unpublishedReasonSelect = document.getElementById('bmlt_admin_single_meeting_editor_' + meeting_id + '_unpublished_reason_select');
-        unpublishedReasonSelect.value = in_meeting_object.unpublished_reason ? in_meeting_object.unpublished_reason : "";
+        var unpublishedReason = in_meeting_object.unpublished_reason ? in_meeting_object.unpublished_reason : "";
+        for (var i = 0; i < unpublishedReasonSelect.options.length; i++) {
+            if (unpublishedReasonSelect.options[i].value === unpublishedReason) {
+                unpublishedReasonSelect.options[i].selected = true;
+                break;
+            }
+        }
 
         this.reactToUnpublishReasonSelect(meeting_id);
 
@@ -2487,10 +2493,8 @@ function BMLT_Server_Admin()
         var mainUnpublishedDiv = unpublishedReasonSelect.parentNode.parentNode;
         if (published_checkbox.checked) {
             mainUnpublishedDiv.className += ' item_hidden';
-            the_meeting_object.unpublished_reason = "";
         } else {
             mainUnpublishedDiv.className = mainUnpublishedDiv.className.replace(" item_hidden", "");
-            the_meeting_object.unpublished_reason = unpublishedReasonSelect.value;
         }
 
         this.validateMeetingEditorButton(in_meeting_id);

--- a/main_server/server/classes/c_comdef_meeting.class.php
+++ b/main_server/server/classes/c_comdef_meeting.class.php
@@ -874,6 +874,7 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         $ret['longitude']['key'] = 'longitude';
         $ret['latitude']['key'] = 'latitude';
         $ret['published']['key'] = 'published';
+        $ret['unpublished_reason']['key'] = 'unpublished_reason';
         $ret['email_contact']['key'] = 'email_contact';
         
         // Everything gets a lang_enum (determined by global server setting).

--- a/main_server/server/classes/c_comdef_meeting.class.php
+++ b/main_server/server/classes/c_comdef_meeting.class.php
@@ -702,6 +702,7 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
                 case 'email_contact':
                 case 'distance_in_km':
                 case 'distance_in_miles':
+                case 'unpublished_reason':
                 case 'published':
                     break;
                 

--- a/main_server/server/classes/c_comdef_meeting.class.php
+++ b/main_server/server/classes/c_comdef_meeting.class.php
@@ -132,6 +132,11 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         } else {
             $main_table_values['published'] = 0;
         }
+        if (isset($this->_my_meeting_data['unpublished_reason']) && !$main_table_values['published']) {
+            $main_table_values['unpublished_reason'] = $this->_my_meeting_data['unpublished_reason'];
+        } else {
+            $main_table_values['unpublished_reason'] = "";
+        }
         
         // Now, we "unwind" the formats. Remember that we made the formats into an array, and replaced the values with objects, so we just use the keys here.
         $main_table_values['formats'] = "";
@@ -149,6 +154,7 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         foreach ($this->_my_meeting_data as $key => $value2) {
             // We ignore the values in the main table.
             switch ($key) {
+                case 'unpublished_reason':
                 case 'published':
                 case 'id_bigint':
                 case 'worldid_mixed':
@@ -669,6 +675,7 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         }
         
         $ret['published'] = 'published';    // The last field is always the published flag.
+        $ret['unpublished_reason'] = 'unpublished_reason';
         return $ret;
     }
     

--- a/main_server/server/classes/c_comdef_meetings.class.php
+++ b/main_server/server/classes/c_comdef_meetings.class.php
@@ -558,6 +558,7 @@ class c_comdef_meetings implements i_comdef_has_parent
                             case 'longitude':
                             case 'latitude':
                             case 'published':
+                            case 'unpublished_reason':
                             case 'email_contact':
                                 break;
                             


### PR DESCRIPTION
- [x] Add unpublished reason to UI
- [x] Handle unpublished reason on the backend
- [ ] Test iOS admin app
- [ ] Determine appropriate canned responses for unpublished reason
- [ ] Add `unpublished_reason` column to the NAWS csv
- [ ] Add message to the UI explaining that unpublished should not be used to indicate a meeting has permanently closed.
- [ ] Add strings to translation files
- [ ] Make sure cache busting is added to the js file before merging

Closes https://github.com/bmlt-enabled/bmlt-root-server/issues/82