### PR TITLE
make meetings default to published when creating a new meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ For instructions on installing the root server, see [the page on installing a ne
 
 CHANGELIST
 ----------
+***Version 2.13.4* ** *- UNRELEASED*
+
+- Meetings are now published by default when creating a new meeting. To change this back to default to unpublished you would need to add the following to your `auto-config.inc.php`.
+    - `$default_meeting_published = false;`
+
 ***Version 2.13.3* ** *- July 7, 2019*
 
 - When saving a change to a meeting, the edit screen for that meeting is no longer closed. This makes it easier for the user to keep their place in the user interface.

--- a/main_server/client_interface/serverInfo.xml
+++ b/main_server/client_interface/serverInfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <bmltInfo>
 	<serverVersion>
-		<readableString>2.13.3</readableString>
+		<readableString>2.13.4</readableString>
 	</serverVersion>
 </bmltInfo>

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -318,6 +318,7 @@ class c_comdef_admin_main_console
                 $ret .= 'var g_style_dir = \''.self::js_html((((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/style').'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= 'var g_Create_new_meeting_button_name = \''.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['meeting_create_button_name']).'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= 'var g_Save_meeting_button_name = \''.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['meeting_save_buttonName']).'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');
+                $ret .= 'var g_default_meeting_published = \''.self::js_html($this->my_localized_strings['default_meeting_published']).'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= 'var g_default_meeting_weekday = '.intVal($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_default_weekday']).';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= 'var g_default_meeting_start_time = \''.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_default_start_time']).'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= 'var g_default_meeting_duration = \''.self::js_html($this->my_localized_strings['default_duration_time']).'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');

--- a/main_server/local_server/server_admin/server_admin_javascript.js
+++ b/main_server/local_server/server_admin/server_admin_javascript.js
@@ -617,7 +617,7 @@ function BMLT_Server_Admin()
 
             ret.weekday_tinyint = g_default_meeting_weekday.toString();
             ret.id_bigint = 0;  // All new meetings are ID 0.
-            ret.published = '0';
+            ret.published = g_default_meeting_published;
             ret.service_body_bigint = g_service_bodies_array[0][0].toString();
             ret.formats = '';
             ret.format_shared_id_list = '';

--- a/main_server/server/c_comdef_server.class.php
+++ b/main_server/server/c_comdef_server.class.php
@@ -2682,6 +2682,7 @@ class c_comdef_server
                 global  $comdef_global_more_details_address,    ///< This is a format string for the way the address line is displayed in the "more details" screen.
                     $comdef_global_list_address;            ///< The same, but for the list.
 
+                c_comdef_server::$server_local_strings['default_meeting_published'] = isset($default_meeting_published) ? $default_meeting_published : true;
                 c_comdef_server::$server_local_strings['week_starts_on'] = (isset($week_starts_on) && (-1 < $week_starts_on) && (7 > $week_starts_on)) ? $week_starts_on : 0;
                 c_comdef_server::$server_local_strings['name'] = file_get_contents(dirname(dirname(__FILE__)).'/local_server/server_admin/lang/'.$lang_enum.'/name.txt');
                 c_comdef_server::$server_local_strings['enum'] = $lang_enum;


### PR DESCRIPTION
Per discussion from last scrum. Many service bodies have had problems with users creating meetings and not publishing them, this is more than just not training them properly. Meetings will now be published by default when creating a new meeting. If a root server wants to reverse this change they can add `$default_meeting_published = false;` to their `auto-config.inc.php`

resolves #194