### PR TITLE
change jsonp mime type to recommended one

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ For instructions on installing the root server, see [the page on installing a ne
 
 CHANGELIST
 ----------
+***Version 2.13.6* ** *- UNRELEASED*
+
+- Changed JSONP mime type to `application/javascript`
+
 ***Version 2.13.5* ** *- August 15, 2019*
 
 - Fix for NAWS format types not saving correctly in the root server administration.

--- a/main_server/client_interface/jsonp/GetLangs.php
+++ b/main_server/client_interface/jsonp/GetLangs.php
@@ -33,7 +33,7 @@ if ($server instanceof c_comdef_server) {
         if (isset($_GET['compress_json']) || isset($_POST['compress_json'])) {
             ob_start('ob_gzhandler');
         } else {
-            header('Content-Type:text/javascript; charset=UTF-8');
+            header('Content-Type:application/javascript; charset=UTF-8');
             ob_start();
         }
 

--- a/main_server/client_interface/jsonp/index.php
+++ b/main_server/client_interface/jsonp/index.php
@@ -44,7 +44,7 @@ try {
                 ob_start();
             }
         } else {
-            header('Content-Type:text/javascript; charset=UTF-8');
+            header('Content-Type:application/javascript; charset=UTF-8');
             ob_start();
         }
         

--- a/main_server/client_interface/serverInfo.xml
+++ b/main_server/client_interface/serverInfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <bmltInfo>
 	<serverVersion>
-		<readableString>2.13.5</readableString>
+		<readableString>2.13.6</readableString>
 	</serverVersion>
 </bmltInfo>


### PR DESCRIPTION
text/javascript is obsolete
the standard is registered as application/javascript by the Internet Engineering Task Force (IETF)

https://www.iana.org/assignments/media-types/media-types.xhtml