### PR TITLE
fix for naws dropdown sorting by key instead of value

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ CHANGELIST
 - Changed JSONP mime type to `application/javascript`
 - Rename "Get A NAWS Format Dump" to "Get A NAWS Format Export" in the semantic workshop
 - Fixed an issue where the admin user interface could falsely think a meeting had been edited
-- Fix for NAWS format drop down not sorting correctly.
+- Fix for NAWS format drop-down not sorting correctly in the root server administration.
 
 ***Version 2.13.5* ** *- August 15, 2019*
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ CHANGELIST
 - Changed JSONP mime type to `application/javascript`
 - Rename "Get A NAWS Format Dump" to "Get A NAWS Format Export" in the semantic workshop
 - Fixed an issue where the admin user interface could falsely think a meeting had been edited
-
-
 - Fix for NAWS format drop down not sorting correctly.
 
 ***Version 2.13.5* ** *- August 15, 2019*

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ CHANGELIST
 - Rename "Get A NAWS Format Dump" to "Get A NAWS Format Export" in the semantic workshop
 - Fixed an issue where the admin user interface could falsely think a meeting had been edited
 
+
+- Fix for NAWS format drop down not sorting correctly.
+
 ***Version 2.13.5* ** *- August 15, 2019*
 
 - Fix for NAWS format types not saving correctly in the root server administration.

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -381,8 +381,13 @@ class c_comdef_admin_main_console
                 $ret .= 'var g_naws_popup_prompt = \''.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes_prompt']).'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= "var g_naws_values = [";
                     $n_first = true;
+            // This sorts the NAWS codes in the format server admin. The drop-down menu is sorted by value and the key is the drop-down menu value.
+            // The first field key is empty and value is 'None', if we sort by key value this field will no longer be the top element.
+            // So we shift it off the array...
             $top_elm = array_shift($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes']);
+            // Then we can sort
             asort($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes']);
+            // and now we unshift it too put it back on the top element.
             array_unshift($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes'], $top_elm);
         foreach ($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes'] as $key => $value) {
             if (!$n_first) {

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -387,7 +387,7 @@ class c_comdef_admin_main_console
             $top_elm = array_shift($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes']);
             // Then we can sort
             asort($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes']);
-            // and now we unshift it too put it back on the top element.
+            // and now we unshift it to put it back as the top element.
             array_unshift($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes'], $top_elm);
         foreach ($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes'] as $key => $value) {
             if (!$n_first) {

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -381,7 +381,9 @@ class c_comdef_admin_main_console
                 $ret .= 'var g_naws_popup_prompt = \''.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes_prompt']).'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= "var g_naws_values = [";
                     $n_first = true;
-            ksort($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes']);
+            $top_elm = array_shift($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes']);
+            asort($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes']);
+            array_unshift($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes'], $top_elm);
         foreach ($this->my_localized_strings['comdef_server_admin_strings']['world_format_codes'] as $key => $value) {
             if (!$n_first) {
                 $ret .= ','.(defined('__DEBUG_MODE__') ? "\n" : '');


### PR DESCRIPTION
the last fix was silly, this one may be too. But i was sorting by key and really needed to sort by value. Because the default dropdown is the top one and that key is null. im shifting it off sorting and then unshifting it.