### PR TITLE
css fix for meeting editor labels with non english servers

### DIFF
--- a/main_server/local_server/server_admin/style/styles.css
+++ b/main_server/local_server/server_admin/style/styles.css
@@ -193,7 +193,7 @@ span.weekday_checkbox_span label.bmlt_admin_med_checkbox_label_left
 
 .bmlt_admin_med_label_right
 {
-    width:20em;
+    width:28em;
     text-align:right;
 }
 


### PR DESCRIPTION
the meeting editor is squishing the label for most languages except English, this will fix it

![Screen Shot 2019-12-03 at 4 14 09 PM](https://user-images.githubusercontent.com/34245618/70094140-e1548080-15ef-11ea-8541-407c717407fb.png)

