### PR TITLE
Automatically populate zip and county from geocode results

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ CHANGELIST
 ***Version 2.14.6* ** *- TBD*
 
 - Geocoding does not work well in all parts of the world, so automatic geocoding of meetings is now optional. It is enabled by default, and can disabled by adding `$auto_geocoding_enabled = false;` to `auto-config.inc.php`.
+- When `$county_auto_geocoding_enabled = true;` is set in `auto-config.inc.php`, the County field becomes read-only and is automatically populated by geocoding when a meeting is saved.
+- When `$zip_auto_geocoding_enabled = true;` is set in `auto-config.inc.php`, the Zip Code field becomes read-only and is automatically populated by geocoding when a meeting is saved. 
 
 ***Version 2.14.5* ** *- December 7, 2019*
 

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -166,6 +166,8 @@ class c_comdef_admin_main_console
                 $ret .= 'var g_check_all_text = \''.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['check_all']).'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= 'var g_uncheck_all_text = \''.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['uncheck_all']).'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= 'var g_auto_geocoding_enabled = '.self::js_html($this->my_localized_strings['auto_geocoding_enabled'] ? 'true' : 'false').';'.(defined('__DEBUG_MODE__') ? "\n" : '');
+                $ret .= 'var g_county_auto_geocoding_enabled = '.self::js_html($this->my_localized_strings['county_auto_geocoding_enabled'] ? 'true' : 'false').';'.(defined('__DEBUG_MODE__') ? "\n" : '');
+                $ret .= 'var g_zip_auto_geocoding_enabled = '.self::js_html($this->my_localized_strings['zip_auto_geocoding_enabled'] ? 'true' : 'false').';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= 'var g_maps_api_key_warning  = \''.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['Maps_API_Key_Warning']).'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= 'var g_maps_api_key_not_set  = \''.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['Maps_API_Key_Not_Set']).'\';'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= 'var g_service_bodies_array = [';
@@ -428,7 +430,7 @@ class c_comdef_admin_main_console
              */
             $ret .= '</script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/json2.js"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
-            $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/server_admin_javascript.js"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
+            $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/server_admin_javascript.js?v='.time().'"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             $ret .= '<noscript class="main_noscript">'.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['noscript']).'</noscript>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             // Belt and suspenders. Just make sure the user is legit.
         if (($this->my_user instanceof c_comdef_user) && ($this->my_user->GetUserLevel() != _USER_LEVEL_DISABLED)) {
@@ -1777,7 +1779,7 @@ class c_comdef_admin_main_console
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_county_label']).'</span>';
                     $ret .= '<span class="bmlt_admin_value_left">';
-        if (!$this->my_localized_strings['auto_geocoding_enabled'] && is_array($this->my_localized_strings['meeting_counties_and_sub_provinces']) && count($this->my_localized_strings['meeting_counties_and_sub_provinces'])) {
+        if ((!$this->my_localized_strings['auto_geocoding_enabled'] || !$this->my_localized_strings['county_auto_geocoding_enabled']) && is_array($this->my_localized_strings['meeting_counties_and_sub_provinces']) && count($this->my_localized_strings['meeting_counties_and_sub_provinces'])) {
             $ret .= '<select id="bmlt_admin_single_meeting_editor_template_meeting_county_select_input" class="bmlt_admin_single_meeting_editor_template_meeting_county_select_input">';
             $ret .= '<option value=""></option>';
             foreach ($this->my_localized_strings['meeting_counties_and_sub_provinces'] as $value) {
@@ -1785,10 +1787,10 @@ class c_comdef_admin_main_console
             }
                 $ret .= '</select>';
         } else {
-            $ret .= '<input id="bmlt_admin_single_meeting_editor_template_meeting_county_text_input" type="text" value="'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_county_prompt']).'" '. ($this->my_localized_strings['auto_geocoding_enabled'] ? 'readonly' : '') .' />';
+            $ret .= '<input id="bmlt_admin_single_meeting_editor_template_meeting_county_text_input" type="text" value="'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_county_prompt']).'" '. ($this->my_localized_strings['auto_geocoding_enabled'] && $this->my_localized_strings['county_auto_geocoding_enabled'] ? 'readonly' : '') .' />';
         }
                     $ret .= '</span>';
-        if ($this->my_localized_strings['auto_geocoding_enabled']) {
+        if ($this->my_localized_strings['auto_geocoding_enabled'] && $this->my_localized_strings['county_auto_geocoding_enabled']) {
             $ret .= '<span class="bmlt_admin_visibility_advice_span">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['automatically_calculated_on_save']).'</span>';
         }
                     $ret .= '<div class="clear_both"></div>';
@@ -1811,8 +1813,8 @@ class c_comdef_admin_main_console
                 $ret .= '</div>';
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_zip_label']).'</span>';
-                    $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_zip_text_input" type="text" value="'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_zip_prompt']).'" '. ($this->my_localized_strings['auto_geocoding_enabled'] ? 'readonly' : '') .' /></span>';
-        if ($this->my_localized_strings['auto_geocoding_enabled']) {
+                    $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_zip_text_input" type="text" value="'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_zip_prompt']).'" '. ($this->my_localized_strings['auto_geocoding_enabled'] && $this->my_localized_strings['zip_auto_geocoding_enabled'] ? 'readonly' : '') .' /></span>';
+        if ($this->my_localized_strings['auto_geocoding_enabled'] && $this->my_localized_strings['zip_auto_geocoding_enabled']) {
             $ret .= '<span class="bmlt_admin_visibility_advice_span">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['automatically_calculated_on_save']).'</span>';
         }
                     $ret .= '<div class="clear_both"></div>';

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -428,7 +428,7 @@ class c_comdef_admin_main_console
              */
             $ret .= '</script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/json2.js"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
-            $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/server_admin_javascript.js?v='. time() .'"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
+            $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/server_admin_javascript.js"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             $ret .= '<noscript class="main_noscript">'.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['noscript']).'</noscript>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             // Belt and suspenders. Just make sure the user is legit.
         if (($this->my_user instanceof c_comdef_user) && ($this->my_user->GetUserLevel() != _USER_LEVEL_DISABLED)) {
@@ -1729,11 +1729,17 @@ class c_comdef_admin_main_console
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_longitude_label']).'</span>';
                     $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_longitude_text_input" type="text" value="'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_longitude_prompt']).'" '. ($this->my_localized_strings['auto_geocoding_enabled'] ? 'readonly' : '') .' /></span>';
+        if ($this->my_localized_strings['auto_geocoding_enabled']) {
+            $ret .= '<span class="bmlt_admin_visibility_advice_span">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['automatically_calculated_on_save']).'</span>';
+        }
                     $ret .= '<div class="clear_both"></div>';
                 $ret .= '</div>';
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_latitude_label']).'</span>';
                     $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_latitude_text_input" type="text" value="'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_latitude_prompt']).'" '. ($this->my_localized_strings['auto_geocoding_enabled'] ? 'readonly' : '') .' /></span>';
+        if ($this->my_localized_strings['auto_geocoding_enabled']) {
+            $ret .= '<span class="bmlt_admin_visibility_advice_span">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['automatically_calculated_on_save']).'</span>';
+        }
                     $ret .= '<div class="clear_both"></div>';
                 $ret .= '</div>';
             $ret .= '</div>';
@@ -1771,7 +1777,7 @@ class c_comdef_admin_main_console
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_county_label']).'</span>';
                     $ret .= '<span class="bmlt_admin_value_left">';
-        if (is_array($this->my_localized_strings['meeting_counties_and_sub_provinces']) && count($this->my_localized_strings['meeting_counties_and_sub_provinces'])) {
+        if (!$this->my_localized_strings['auto_geocoding_enabled'] && is_array($this->my_localized_strings['meeting_counties_and_sub_provinces']) && count($this->my_localized_strings['meeting_counties_and_sub_provinces'])) {
             $ret .= '<select id="bmlt_admin_single_meeting_editor_template_meeting_county_select_input" class="bmlt_admin_single_meeting_editor_template_meeting_county_select_input">';
             $ret .= '<option value=""></option>';
             foreach ($this->my_localized_strings['meeting_counties_and_sub_provinces'] as $value) {
@@ -1779,9 +1785,12 @@ class c_comdef_admin_main_console
             }
                 $ret .= '</select>';
         } else {
-            $ret .= '<input id="bmlt_admin_single_meeting_editor_template_meeting_county_text_input" type="text" value="'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_county_prompt']).'" />';
+            $ret .= '<input id="bmlt_admin_single_meeting_editor_template_meeting_county_text_input" type="text" value="'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_county_prompt']).'" '. ($this->my_localized_strings['auto_geocoding_enabled'] ? 'readonly' : '') .' />';
         }
                     $ret .= '</span>';
+        if ($this->my_localized_strings['auto_geocoding_enabled']) {
+            $ret .= '<span class="bmlt_admin_visibility_advice_span">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['automatically_calculated_on_save']).'</span>';
+        }
                     $ret .= '<div class="clear_both"></div>';
                 $ret .= '</div>';
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
@@ -1802,7 +1811,10 @@ class c_comdef_admin_main_console
                 $ret .= '</div>';
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_zip_label']).'</span>';
-                    $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_zip_text_input" type="text" value="'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_zip_prompt']).'" /></span>';
+                    $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_zip_text_input" type="text" value="'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_zip_prompt']).'" '. ($this->my_localized_strings['auto_geocoding_enabled'] ? 'readonly' : '') .' /></span>';
+        if ($this->my_localized_strings['auto_geocoding_enabled']) {
+            $ret .= '<span class="bmlt_admin_visibility_advice_span">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['automatically_calculated_on_save']).'</span>';
+        }
                     $ret .= '<div class="clear_both"></div>';
                 $ret .= '</div>';
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -430,7 +430,7 @@ class c_comdef_admin_main_console
              */
             $ret .= '</script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/json2.js"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
-            $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/server_admin_javascript.js?v='.time().'"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
+            $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/server_admin_javascript.js?v='. time() .'"></script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             $ret .= '<noscript class="main_noscript">'.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['noscript']).'</noscript>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             // Belt and suspenders. Just make sure the user is legit.
         if (($this->my_user instanceof c_comdef_user) && ($this->my_user->GetUserLevel() != _USER_LEVEL_DISABLED)) {

--- a/main_server/local_server/server_admin/lang/de/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/de/server_admin_strings.inc.php
@@ -391,7 +391,8 @@
                                                                                                                 'email_contact' => 'E-Mail Kontakt',
                                                                                                                 ),
                                             'check_all'                                             => 'Check All',
-                                            'uncheck_all'                                           => 'Uncheck All'
+                                            'uncheck_all'                                           => 'Uncheck All',
+                                            'automatically_calculated_on_save'                      => 'Automatically calculated on save.'
                                         );
 
     $email_contact_strings = array (

--- a/main_server/local_server/server_admin/lang/dk/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/dk/server_admin_strings.inc.php
@@ -397,7 +397,8 @@ $comdef_server_admin_strings = array (
         'email_contact' => 'Email Kontakt',
     ),
     'check_all'                                             => 'Check All',
-    'uncheck_all'                                           => 'Uncheck All'
+    'uncheck_all'                                           => 'Uncheck All',
+    'automatically_calculated_on_save'                      => 'Automatically calculated on save.'
 );
 
 $email_contact_strings = array (

--- a/main_server/local_server/server_admin/lang/en/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/en/server_admin_strings.inc.php
@@ -394,7 +394,8 @@
                                                                                                                 'email_contact' => 'Email Contact',
                                                                                                                 ),
                                             'check_all'                                             => 'Check All',
-                                            'uncheck_all'                                           => 'Uncheck All'
+                                            'uncheck_all'                                           => 'Uncheck All',
+                                            'automatically_calculated_on_save'                      => 'Automatically calculated on save.'
                                         );
 
     $email_contact_strings = array (

--- a/main_server/local_server/server_admin/lang/es/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/es/server_admin_strings.inc.php
@@ -392,7 +392,8 @@
                                                                                                                 'email_contact' => 'Email Contact',
                                                                                                                 ),
                                             'check_all'                                             => 'Check All',
-                                            'uncheck_all'                                           => 'Uncheck All'
+                                            'uncheck_all'                                           => 'Uncheck All',
+                                            'automatically_calculated_on_save'                      => 'Automatically calculated on save.'
                                         );
 
     $email_contact_strings = array (

--- a/main_server/local_server/server_admin/lang/fa/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/fa/server_admin_strings.inc.php
@@ -394,7 +394,8 @@
                                                                                                                 'email_contact' => 'Email Contact',
                                                                                                                 ),
                                             'check_all'                                             => 'Check All',
-                                            'uncheck_all'                                           => 'Uncheck All'
+                                            'uncheck_all'                                           => 'Uncheck All',
+                                            'automatically_calculated_on_save'                      => 'Automatically calculated on save.'
                                         );
 
     $email_contact_strings = array (

--- a/main_server/local_server/server_admin/lang/fr/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/fr/server_admin_strings.inc.php
@@ -392,7 +392,8 @@
                                                                                                                 'email_contact' => 'Email Contact',
                                                                                                                 ),
                                             'check_all'                                             => 'Check All',
-                                            'uncheck_all'                                           => 'Uncheck All'
+                                            'uncheck_all'                                           => 'Uncheck All',
+                                            'automatically_calculated_on_save'                      => 'Automatically calculated on save.'
                                         );
 
     $email_contact_strings = array (

--- a/main_server/local_server/server_admin/lang/it/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/it/server_admin_strings.inc.php
@@ -389,7 +389,8 @@
                                                                                                                 'email_contact' => 'Contatto email',//'Email Contact',
                                                                                                                 ),
                                             'check_all'                                             => 'Check All',
-                                            'uncheck_all'                                           => 'Uncheck All'
+                                            'uncheck_all'                                           => 'Uncheck All',
+                                            'automatically_calculated_on_save'                      => 'Automatically calculated on save.'
                                         );
 
     $email_contact_strings = array (

--- a/main_server/local_server/server_admin/lang/pl/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/pl/server_admin_strings.inc.php
@@ -382,7 +382,8 @@
                                                                                                                 'email_contact' => 'Kontakt e-mail',
                                                                                                         ),
                                             'check_all'                                             => 'Check All',
-                                            'uncheck_all'                                           => 'Uncheck All'
+                                            'uncheck_all'                                           => 'Uncheck All',
+                                            'automatically_calculated_on_save'                      => 'Automatically calculated on save.'
                                    );
     $email_contact_strings = array (
         'meeting_contact_form_subject_format'   =>  "[MEETING LIST CONTACT] %s",

--- a/main_server/local_server/server_admin/lang/sv/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/sv/server_admin_strings.inc.php
@@ -393,7 +393,8 @@
                                                                                                                 'email_contact' => 'Email Contact',
                                                                                                                 ),
                                             'check_all'                                             => 'Check All',
-                                            'uncheck_all'                                           => 'Uncheck All'
+                                            'uncheck_all'                                           => 'Uncheck All',
+                                            'automatically_calculated_on_save'                      => 'Automatically calculated on save.'
                                         );
 
     $email_contact_strings = array (

--- a/main_server/local_server/server_admin/server_admin_javascript.js
+++ b/main_server/local_server/server_admin/server_admin_javascript.js
@@ -1757,12 +1757,12 @@ function BMLT_Server_Admin()
 
                 var meeting_state_text_input = document.getElementById(meeting_state_text_item_id);
                 if (meeting_state_text_input !== null) {
-                    this.handleTextInputLoad(meeting_state_text_input, null, g_auto_geocoding_enabled);
+                    this.handleTextInputLoad(meeting_state_text_input, null, g_auto_geocoding_enabled && g_county_auto_geocoding_enabled);
                 }
 
                 var meeting_county_text_input = document.getElementById(meeting_county_text_item_id);
                 if (meeting_county_text_input !== null) {
-                    this.handleTextInputLoad(meeting_county_text_input, null, g_auto_geocoding_enabled);
+                    this.handleTextInputLoad(meeting_county_text_input, null, g_auto_geocoding_enabled && g_county_auto_geocoding_enabled);
                 }
                 
                 var map_disclosure_a = document.getElementById('bmlt_admin_single_meeting_editor_' + in_meeting_id + '_map_disclosure_a');
@@ -2702,7 +2702,7 @@ function BMLT_Server_Admin()
                     google.maps.event.removeListener(the_meeting_object.m_geocoder);
                 }
 
-                if (g_auto_geocoding_enabled) {
+                if (g_auto_geocoding_enabled && g_county_auto_geocoding_enabled) {
                     var meeting_county_text_item = document.getElementById('bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_county_text_input');
                     if (meeting_county_text_item) {
                         for (var i = 0; i < in_geocode_response[0].address_components.length; i++) {
@@ -2720,7 +2720,7 @@ function BMLT_Server_Admin()
                     }
                 }
 
-                if (g_auto_geocoding_enabled) {
+                if (g_auto_geocoding_enabled && g_county_auto_geocoding_enabled) {
                     var meeting_zip_text_item = document.getElementById('bmlt_admin_single_meeting_editor_' + in_meeting_id + '_meeting_zip_text_input');
                     if (meeting_zip_text_item) {
                         if (meeting_county_text_item) {

--- a/main_server/server/c_comdef_server.class.php
+++ b/main_server/server/c_comdef_server.class.php
@@ -2653,6 +2653,8 @@ class c_comdef_server
                 }
 
                 c_comdef_server::$server_local_strings['auto_geocoding_enabled'] = isset($auto_geocoding_enabled) ? $auto_geocoding_enabled : true;
+                c_comdef_server::$server_local_strings['zip_auto_geocoding_enabled'] = isset($zip_auto_geocoding_enabled) ? $zip_auto_geocoding_enabled : true;
+                c_comdef_server::$server_local_strings['county_auto_geocoding_enabled'] = isset($county_auto_geocoding_enabled) ? $county_auto_geocoding_enabled : true;
                 c_comdef_server::$server_local_strings['sort_formats'] = isset($sort_formats) ? $sort_formats : true;
                 c_comdef_server::$server_local_strings['meeting_counties_and_sub_provinces'] = isset($meeting_counties_and_sub_provinces) ? $meeting_counties_and_sub_provinces : array();
                 c_comdef_server::$server_local_strings['meeting_states_and_provinces'] = isset($meeting_states_and_provinces) ? $meeting_states_and_provinces : array();

--- a/main_server/server/c_comdef_server.class.php
+++ b/main_server/server/c_comdef_server.class.php
@@ -2653,8 +2653,8 @@ class c_comdef_server
                 }
 
                 c_comdef_server::$server_local_strings['auto_geocoding_enabled'] = isset($auto_geocoding_enabled) ? $auto_geocoding_enabled : true;
-                c_comdef_server::$server_local_strings['zip_auto_geocoding_enabled'] = isset($zip_auto_geocoding_enabled) ? $zip_auto_geocoding_enabled : true;
-                c_comdef_server::$server_local_strings['county_auto_geocoding_enabled'] = isset($county_auto_geocoding_enabled) ? $county_auto_geocoding_enabled : true;
+                c_comdef_server::$server_local_strings['zip_auto_geocoding_enabled'] = isset($zip_auto_geocoding_enabled) ? $zip_auto_geocoding_enabled : false;
+                c_comdef_server::$server_local_strings['county_auto_geocoding_enabled'] = isset($county_auto_geocoding_enabled) ? $county_auto_geocoding_enabled : false;
                 c_comdef_server::$server_local_strings['sort_formats'] = isset($sort_formats) ? $sort_formats : true;
                 c_comdef_server::$server_local_strings['meeting_counties_and_sub_provinces'] = isset($meeting_counties_and_sub_provinces) ? $meeting_counties_and_sub_provinces : array();
                 c_comdef_server::$server_local_strings['meeting_states_and_provinces'] = isset($meeting_states_and_provinces) ? $meeting_states_and_provinces : array();


### PR DESCRIPTION
Three settings:
- `$auto_geocoding_enabled`
- `$zip_auto_geocoding_enabled`
- `$county_auto_geocoding_enabled`

**`$auto_geocoding_enabled`**: The default value is `true`. Enabling `$auto_geocoding_enabled` by itself just turns on auto geocoding for the latitude and longitude fields.

**`$zip_auto_geocoding_enabled`**: The default value is `false`. If both `$auto_geocoding_enabled` and `$zip_auto_geocoding_enabled` are `true`, the zip code field becomes readonly, and is automatically populated by geocoding on save.

**`$county_auto_geocoding_enabled`**: The default value is `false`. If both `$auto_geocoding_enabled` and `$county_auto_geocoding_enabled` are `true`, the county field becomes readonly, and is automatically populated by geocoding on save.
