### PR TITLE
allow unauthenticated users to use advanced_published option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ CHANGELIST
 ----------
 ***Version 2.15.2* ** *- UNRELEASED*
 - Added Russian translation.
+- Fixed an issue with the NAWS export where unauthenticated exports would not return unpublished meetings.
 
 ***Version 2.15.1* ** *- March 28, 2020*
 - Added `VM` format for Virtual Meetings (pandemic response).

--- a/main_server/client_interface/csv/common_search.inc.php
+++ b/main_server/client_interface/csv/common_search.inc.php
@@ -414,7 +414,7 @@ function SetUpSearch(
         }
         
         // Next, set up the advanced published option.
-        if (isset($in_http_vars['advanced_published']) && (c_comdef_server::GetCurrentUserObj() instanceof c_comdef_user)) {
+        if (isset($in_http_vars['advanced_published'])) {
             $in_search_manager->SetPublished(intval($in_http_vars['advanced_published']));
         } else {
             $in_search_manager->SetPublished(1);


### PR DESCRIPTION
The reason I am doing this is because I want anyone to have the ability to do a NAWS Export and include all of the unpublished meeting data that Lori expects.

I also don't think hiding this data from unauthenticated users provides any value - it doesn't contain PII or anything.

Unpublished meetings are only returned when `&advanced_published=1` is passed with the query string, or when performing a NAWS Export.