### PR TITLE
add virtual_meeting_additional_info field to NAWS export

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For instructions on installing the root server, see [the page on installing a ne
 CHANGELIST
 ----------
 ***Version 2.15.4* ** *- TBD*
-- Added the new "Virtual Meeting Additional Info" field to the root server and semantic API output.
+- Added the new "Virtual Meeting Additional Info" field to the root server, semantic API output, and NAWS export.
 
 ***Version 2.15.3* ** *- June 27, 2020*
 - Added `services` and `recursive` parameters to `GetServiceBodies`, allowing service bodies to be filtered.

--- a/main_server/client_interface/csv/search_results_csv.php
+++ b/main_server/client_interface/csv/search_results_csv.php
@@ -612,6 +612,7 @@ function ReturnNAWSFormatCSV(
                                     'ContactGP'          => null,
                                     'PhoneMeetingNumber' => 'phone_meeting_number',
                                     'VirtualMeetingLink' => 'virtual_meeting_link',
+                                    'VirtualMeetingInfo' => 'virtual_meeting_additional_info',
                                     'bmlt_id'            => 'id_bigint',
                                     'unpublished'        => 'BMLT_FuncNAWSReturnPublishedStatus'
                                 );


### PR DESCRIPTION
This adds NAWS export support for the virtual_meeting_additional_info field that was added in #309.