### PR TITLE
add CONTRIBUTING.md file about how to set up a dev environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to the BMLT Root Server
+
+For general information about BMLT, including ways to contribute to the project, please see
+[the BMLT Documentation Site](https://bmlt.app).
+
+This file contains information specifically about how to set up a development environment to work on the root server.
+We want the server code (as well as code for the other project core elements) to continue to be of high quality, so
+prospective developers should have a solid grounding in good software engineering practice. In other words, making
+changes to the server code wouldn't be the best place to start for folks new to software development -- there are, on
+the other hand, lots of other parts of the project that could very much use your time and energy! (An exception is
+that we do frequently need fluent speakers of languages other than English to translate localization strings -- even
+if the initial translation has already been done, there are often new strings added in subsequent development work
+that need translation.)
+
+There are various ways you can set up your development environment; in the directions here we use
+[Docker](https://www.docker.com). If you don't have it already, install
+[Docker Desktop](https://www.docker.com/products/docker-desktop). Then go to the `docker` directory, which contains the
+Dockerfiles for building images for both the BMLT Root Server and a MySQL database with sample data for testing
+purposes. These images get pushed to `https://hub.docker.com/r/bmltenabled/bmlt-root-server/` and 
+`https://hub.docker.com/r/bmltenabled/bmlt-root-server-sample-db/` respectively. They can be started together
+using `docker compose`.
+
+## How to use
+1. Edit `bmlt.env` to set your google maps api key, `GKEY=API_KEY`
+2. Run the command `make run`
+3. Browse to `http://localhost:8000/main_server/`
+4. Login with username "serveradmin" and password "CoreysGoryStory"
+5. When finished, exit by pressing ctrl+c or by running `docker-compose down`
+
+## Supported environment variables
+This is an example `bmlt.env` file. The value for each of these variables, on start of the container, is automatically written to the appropriate line in `auto-config.inc.php`.
+```
+GKEY=
+DBNAME=bmlt
+DBUSER=bmlt_user
+DBPASSWORD=bmlt_password
+DBSERVER=db
+DBPREFIX=na
+```
+
+## Testing the Install Wizard
+The Docker files automatically set up an `auto-config.inc.php` file for you. Usually this is great since it saves you
+the bother of going through the install wizard each time you restart the root server. However, if you want to test or
+change the install wizard, you can start with the install wizard instead of the login screen by deleting this file.
+Here are modified steps to do that.
+1. Edit `bmlt.env` to set your google maps api key, `GKEY=API_KEY`
+2. Run the command `make run`
+3. Run `docker exec -it docker_bmlt_1 bash` to open a bash shell accessing the container's file system. You will be in
+the directory `/var/www/html/`.
+4. In the bash shell run `rm auto-config.inc.php`.
+5. Leave the shell open so that you can check whether the installer generated a new `auto-config.inc.php` and if so what it contains.
+6. Browse to `http://localhost:8000/main_server/`
+7. In the browser you will now be in the Install Wizard. Start by filling in the Database Connection Settings screen as follows.
+```
+Database Type: mysql
+Database Host: db
+Table Prefix: na2
+Database Name: bmlt
+Database User: bmlt_user
+Database Password: bmlt_password
+```
+Note that the Database Host is `db` rather than the usual `localhost`. If you start with the install wizard, normally
+you need an empty database, but the `bmlt` database already contains sample data. A convenient alternative to creating
+a new database is to use the provided `bmlt` database, and to change the Table Prefix to `na2`, as above.  If you need
+to run the installer again, just use a new Table Prefix each time (`na3` etc). If you do need to access mysql, open
+another shell using `docker exec -it docker_db_1 bash`, and then run `mysql -u bmlt_user -p`.
+
+Finally, as with the earlier directions, when finished exit by pressing ctrl+c or by running `docker-compose down`
+
+## To debug in IntelliJ (see screenshots below for more detail)
+
+1. Add a new configuration (ensure that you have added PHP support).
+2. Select `PHP Remote Debug`
+3. Add a new server, hitting the 3 dots to the right of the input box.
+4. Add a server called "localhost 8000".
+5. Point to hostname "localhost" and port "8000".
+6. Add a path mapping for the first folder mapping to `/var/www/html`.
+7. Save.
+8. Set IDE key to `ROOT_SERVER_DEBUG`.
+9. Save.
+10. Turn on remote debugging by press the button in the toolbar. ![image1](img/3.png)
+11. Set any breakpoints, and the code should pause there.
+
+![image1](docker/img/1.png)
+![image2](docker/img/2.png)

--- a/README.md
+++ b/README.md
@@ -8,34 +8,23 @@ DESCRIPTION
 The Basic Meeting List Toolbox (BMLT, hereafter) is a very powerful client/server system
 that has been written for a very specific purpose, for a very specific clientele.
 
-It is designed to track and locate Narcotics Anonymous meetings, which are regularly-
-scheduled weekly, recurring events.
+It is designed to track and locate Narcotics Anonymous meetings, which are regularly-scheduled, weekly, recurring events.
 
-The intended clientele is Narcotics Anonymous Service bodies. They implement a BMLT
-server, and provide the server to other NA Service bodies.
+The original intended clientele is Narcotics Anonymous Service bodies (although other 12 step fellowships have started
+using BMLT as well). The service body implements a BMLT server, and provides the server to other NA Service bodies.
+This project is the "root" server for the BMLT. It is the "server" part of the BMLT "client/server" architecture.
 
-You can find out way too much about the BMLT on [the BMLT Documentation Site](https://bmlt.app).
+You can find out way too much about the BMLT on [the BMLT Documentation Site](https://bmlt.app), including information
+on lots of ways you can contribute to the project.
+
+The source files are hosted on [GitHub](https://github.com).
+
+[Follow this link to access the BMLT Root Server GitHub repository](https://github.com/bmlt-enabled/BMLT-Root-Server).
+There are also links to various predecessor legacy repositories [here](#older-repositories) at the end of this README.
+For specific information on setting up a development environment for work on the BMLT root server, please
+see [CONTRIBUTING.md](CONTRIBUTING.md) in the GitHub repository.
 
 [You can follow us on Twitter for release announcements](http://twitter.com/BMLT_NA).
-
-This project is the "root" server for the BMLT. It is the "server" part of the BMLT
-"client/server" architecture.
-
-The project is actually several years old. It is currently hosted on [GitHub](https://github.com).
-
-[Follow this link to see the Current GitHub repository.](https://github.com/bmlt-enabled/BMLT-Root-Server)
-
-[Follow this link to see the legacy BitBucket repository.](https://bitbucket.org/bmlt/bmlt-root-server-deprecated/src/Release/)
-
-[Follow this link to see the legacy GitHub repository.](https://github.com/MAGSHARE/BMLT-Root-Server)
-
-[Follow this link to see the legacy antediluvian repository on SourceForge.](https://sourceforge.net/projects/comdef/).
-
-I decided to start new on [GitHub](https://github.com), as opposed to bringing over the SourceForge project,
-in order to reduce disk space usage, and because it's a pain to rearrange a standard
-SVN structure to Git.
-
-NOTE: The repository origin has been transferred to [Bitbucket](http://bitbucket.org)! [GitHub](http://github.com) is now only archival (ends at version 2.0.2).
 
 REQUIREMENTS
 ------------
@@ -59,6 +48,7 @@ CHANGELIST
 ----------
 ***Version 2.15.6* ** *- TBD*
 - Minor improvements to install wizard. Fix bug regarding names and passwords with single quotes or backslashes (before they would cause a cryptic error; now they are OK -- not that using them is a great idea, but the system shouldn't die strangely). Also, if there is a database access error, and one of the offending fields has whitespace at the beginning or end, give a hint to the user that might be the cause.
+- added a CONTRIBUTING.md file that describes how to set up a dev environment for the root server.
 
 ***Version 2.15.5* ** *- July 25, 2020*
 - Many service bodies are already using an "HY" format for hybrid virtual and in-person meetings, so we made it official - if you don't already have the "HY" format, this release will create it for you.
@@ -2177,3 +2167,21 @@ CHANGELIST
 
 ***Version 1.0a1* ** *- May 11, 2009*
 
+OLDER REPOSITORIES
+------------------
+
+The first BMLT release was in 2009. 
+
+Here are various legacy repositories that are predecessors to the
+[current BMLT Root Server GitHub repository](https://github.com/bmlt-enabled/BMLT-Root-Server).
+
+[Follow this link to see the legacy BitBucket repository](https://bitbucket.org/bmlt/bmlt-root-server-deprecated/src/Release/).
+
+[Follow this link to see the legacy GitHub repository](https://github.com/MAGSHARE/BMLT-Root-Server).
+
+[Follow this link to see the legacy antediluvian repository on SourceForge](https://sourceforge.net/projects/comdef/).
+(Note: this link isn't working any more as of July 2020.)
+
+NOTE: The repository origin has been transferred to [Bitbucket](http://bitbucket.org).
+[The legacy GitHub repository](https://github.com/MAGSHARE/BMLT-Root-Server) is now only archival
+(ends at version 2.0.2).


### PR DESCRIPTION
This PR adds a CONTRIBUTING.md file about how to contribute to this project, in particular how to set up a dev environment. This supersedes the docker/README.md file, so that one is deleted. Please check that this has an appropriate balance between welcoming new contributors and saying that we want the code to be high quality and edit as needed!

The main README.md file now references CONTRIBUTING.md; also did some other reorganization of the README. In particular I moved the links to the various legacy predecessor repositories to the end, since I think the recent items on the CHANGELIST will be of more current interest. The link to the "legacy antediluvian repository on SourceForge" doesn't work any more - should that be deleted?