### PR TITLE
allow World IDs to be free form text

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ For instructions on installing the root server, see [Installing a New Root Serve
 ***Version 2.16.0* ** *- UNRELEASED*
 - Field descriptions are now displayed beneath each field to in order to support data validation changes.
 - Added initial support for time zones, hidden behind feature flag.
-- Add a "publish" checkbox to the NAWS import functionality to allow new meetings to be either published or unpublished.
+- Added a "publish" checkbox to the NAWS import functionality to allow new meetings to be either published or unpublished.
 - Fixed an issue where map searches using `geo_width` could return incomplete results when filtered by service body.
 - Fixed an issue with which meeting formats are selected for a NAWS export. NAWS exports are limited to 5 formats. `auto-config.inc.php` can now specify an optional variable `$naws_export_formats_at_front` that is an array of formats that should be exported before others. If not present, the default value is `['VM', 'TC', 'HYBD', 'W', 'M', 'GL']`.
+- Allow World IDs to be free form text, to better support current NAWS practice.
 
 ***Version 2.15.6* ** *- September 7, 2020*
 - Added support for the `OLM` NAWS Format code for online meetings.

--- a/main_server/client_interface/csv/csv.php
+++ b/main_server/client_interface/csv/csv.php
@@ -482,17 +482,6 @@ function parse_redirect(
                     } elseif ($meeting_key == 'worldid_mixed') {
                         if ($value != 'NULL') {
                             $value = trim($value);
-                            $is_olm = (preg_match("/^OLM/", $value) != false);
-                            $stripped_id = intval(preg_replace('|[^0-9]*?|', '', $value));
-                            if ($stripped_id == 0) {
-                                $value = 'NULL';
-                            } else {
-                                if ($is_olm) {
-                                    $value = sprintf("OLM%06d", $stripped_id);
-                                } else {
-                                    $value = sprintf("G%08d", $stripped_id);
-                                }
-                            }
                         }
                     }
 

--- a/main_server/client_interface/csv/search_results_csv.php
+++ b/main_server/client_interface/csv/search_results_csv.php
@@ -991,17 +991,7 @@ function BMLT_FuncNAWSReturnMeetingNAWSID(
     }
     
     if ($the_meeting instanceof c_comdef_meeting) {
-        $world_id = trim($the_meeting->GetMeetingDataValue('worldid_mixed'));
-        $is_olm = (preg_match("/^OLM/", $world_id) != false);
-        $world_id = preg_replace('|\D*?|', '', $world_id);
-        $world_id = intval($world_id);
-        if ($world_id) {
-            if ($is_olm) {
-                $ret = sprintf('OLM%06d', $world_id);
-            } else {
-                $ret = sprintf('G%08d', $world_id);
-            }
-        }
+        $ret = trim($the_meeting->GetMeetingDataValue('worldid_mixed'));
     }
     
     return $ret;


### PR DESCRIPTION
This better supports current NAWS practice, which includes for example appending "-dup" to World IDs for duplicate entries.