### PR TITLE
remove duplicat lat

### DIFF
--- a/main_server/client_interface/csv/search_results_csv.php
+++ b/main_server/client_interface/csv/search_results_csv.php
@@ -437,7 +437,7 @@ function DisplaySearchResultsCSV(
                             
                                 if (isset($val)) {
                                     if (($key == 'formats')) {
-                                        if (($key == 'formats') && is_array($val) && count($val)) {
+                                        if (is_array($val) && count($val)) {
                                             $v_ar = array();
                                             foreach ($val as $format) {
                                                 if ($format instanceof c_comdef_format) {
@@ -488,7 +488,6 @@ function DisplaySearchResultsCSV(
                                                 case 'formats':
                                                 case 'lang_enum':
                                                 case 'longitude':
-                                                case 'latitude':
                                                 case 'latitude':
                                                 case 'published':
                                                 case 'email_contact':


### PR DESCRIPTION
removes duplicate lat case from switch and unneeded key check as condition will always be true at that point.