### PR TITLE
add check for duplicate versions of HY, TC, and VM keys to format editor

### DIFF
--- a/main_server/local_server/server_admin/lang/de/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/de/server_admin_strings.inc.php
@@ -323,6 +323,7 @@ $comdef_server_admin_strings = array(
     'format_editor_delete_button_confirm' => 'Bist du sicher, dass du dieses Format löschen willst?',
     'format_editor_delete_button_confirm_perm' => 'Dieses Format wird dauerhaft gelöscht werden!',
     'format_editor_missing_key' => 'This format should have an entry for every language (at least a key).',   // TODO: translate
+    'format_editor_reserved_key' => 'This key is reserved for a venue type format - please use something different.',       // TODO: translate
     'min_password_length_string' => 'Das Passwort ist zu kurz! Es muss mindestens %d zeichen betragen!',
     'AJAX_Auth_Failure' => 'Authorisation fehlgeschlagen für diese Operation. Es kann sein, dass ein Problem mit der Serverkonfiguration besteht.',
     'Maps_API_Key_Warning' => 'There is a problem with the Google Maps API Key.', // TODO translate

--- a/main_server/local_server/server_admin/lang/dk/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/dk/server_admin_strings.inc.php
@@ -327,6 +327,7 @@ $comdef_server_admin_strings = array(
     'format_editor_delete_button_confirm' => 'Er du sikker på, at du vil slette dette format?',
     'format_editor_delete_button_confirm_perm' => 'Dette format slettes permanent!',
     'format_editor_missing_key' => 'This format should have an entry for every language (at least a key).',   // TODO: translate
+    'format_editor_reserved_key' => 'This key is reserved for a venue type format - please use something different.',       // TODO: translate
     'min_password_length_string' => 'Adgangskoden er for kort! Det skal være mindst% d tegn langt!',
     'AJAX_Auth_Failure' => 'Autorisation mislykkedes for denne operation. Der kan være et problem med serverkonfigurationen.',
     'Maps_API_Key_Warning' => 'ADVARSEL: Der er et problem med API-nøglen til Google Maps.',

--- a/main_server/local_server/server_admin/lang/en/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/en/server_admin_strings.inc.php
@@ -325,6 +325,7 @@ $comdef_server_admin_strings = array(
     'format_editor_delete_button_confirm' => 'Are you sure that you want to delete this format?',
     'format_editor_delete_button_confirm_perm' => 'This format will be deleted permanently!',
     'format_editor_missing_key' => 'This format should have an entry for every language (at least a key).',
+    'format_editor_reserved_key' => 'This key is reserved for a venue type format - please use something different.',
     'min_password_length_string' => 'The password is too short! It must be at least %d characters long!',
     'AJAX_Auth_Failure' => 'Authorization failed for this operation. There may be a problem with the server configuration.',
     'Maps_API_Key_Warning' => 'There is a problem with the Google Maps API Key.',

--- a/main_server/local_server/server_admin/lang/es/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/es/server_admin_strings.inc.php
@@ -324,6 +324,7 @@ $comdef_server_admin_strings = array('server_admin_disclosure' => 'Server Admini
     'format_editor_delete_button_confirm' => '¿Estas seguro que quieres eliminar este formato?',
     'format_editor_delete_button_confirm_perm' => 'Este formato se eliminará para siempre!',
     'format_editor_missing_key' => 'This format should have an entry for every language (at least a key).',   // TODO: translate
+    'format_editor_reserved_key' => 'This key is reserved for a venue type format - please use something different.',       // TODO: translate
     'min_password_length_string' => 'El contraseña es demasiado corta! Debe ser al menos %d caracteres!',
     'AJAX_Auth_Failure' => 'Error en la autorización para esta operación. Puede haber un problema con la configuración del servidor.',
     'Maps_API_Key_Warning' => 'There is a problem with the Google Maps API Key.',

--- a/main_server/local_server/server_admin/lang/fa/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/fa/server_admin_strings.inc.php
@@ -324,6 +324,7 @@ $comdef_server_admin_strings = array('server_admin_disclosure' => 'Server Admini
     'format_editor_delete_button_confirm' => 'Are you sure that you want to delete this format?',
     'format_editor_delete_button_confirm_perm' => 'This format will be deleted permanently!',
     'format_editor_missing_key' => 'This format should have an entry for every language (at least a key).',   // TODO: translate
+    'format_editor_reserved_key' => 'This key is reserved for a venue type format - please use something different.',       // TODO: translate
     'min_password_length_string' => 'The password is too short! It must be at least %d characters long!',
     'AJAX_Auth_Failure' => 'Authorization failed for this operation. There may be a problem with the server configuration.',
     'Maps_API_Key_Warning' => 'There is a problem with the Google Maps API Key.',

--- a/main_server/local_server/server_admin/lang/fr/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/fr/server_admin_strings.inc.php
@@ -323,6 +323,7 @@ $comdef_server_admin_strings = array('server_admin_disclosure' => 'Server Admini
     'need_refresh_message_alert_text' => 'Parce que vous avez fait des changements dd l\'administration de la structure de composante de service, gestion des utilisateurs ou d\'administration de format, les informations affichées dans cette section peuvent ne plus être exactes même si la page doit être rafraîchie. La meilleure façon de le faire est de vous déconnecter, puis vous connecter à nouveau.',
     'format_editor_delete_button_confirm' => 'Etes-vous sûr que vous voulez supprimer ce format?',
     'format_editor_delete_button_confirm_perm' => 'Ce format sera définitivement supprimé!',
+    'format_editor_reserved_key' => 'This key is reserved for a venue type format - please use something different.',       // TODO: translate
     'min_password_length_string' => 'Le mot de passe est trop court! Il doit être au moins contenir au moins %d caractères!',
     'AJAX_Auth_Failure' => 'Échec de l\'autorisation pour cette opération. Il peut y avoir un problème avec la configuration du serveur.',
     'Maps_API_Key_Warning' => 'There is a problem with the Google Maps API Key.',

--- a/main_server/local_server/server_admin/lang/it/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/it/server_admin_strings.inc.php
@@ -323,6 +323,7 @@ $comdef_server_admin_strings = array(
     'format_editor_delete_button_confirm' => 'Sei sicuro di voler cancellare questo formato?', /// 'Are you sure that you want to delete this format?'
     'format_editor_delete_button_confirm_perm' => 'Questo formato sarà cancellato definitivamente!', /// 'This format will be deleted permanently!'
     'format_editor_missing_key' => 'This format should have an entry for every language (at least a key).',   // TODO: translate
+    'format_editor_reserved_key' => 'This key is reserved for a venue type format - please use something different.',       // TODO: translate
     'min_password_length_string' => 'La password è troppo corta! Deve essere lunga almeno %d caratteri!', /// 'The password is too short! It must be at least %d characters long!'
     'AJAX_Auth_Failure' => 'Autorizzazione fallita per questa operazione. Ci potrebbe essere un problema con la configurazione del server.', /// 'Authorization failed for this operation. There may be a problem with the server configuration.'
     'Maps_API_Key_Warning' => 'There is a problem with the Google Maps API Key.',

--- a/main_server/local_server/server_admin/lang/pl/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/pl/server_admin_strings.inc.php
@@ -323,6 +323,7 @@ $comdef_server_admin_strings = array(
     'format_editor_delete_button_confirm' => 'Czy na pewno chcesz usunąć ten format?',
     'format_editor_delete_button_confirm_perm' => 'Ten format zostanie usunięty nieodwracalnie!',
     'format_editor_missing_key' => 'This format should have an entry for every language (at least a key).',   // TODO: translate
+    'format_editor_reserved_key' => 'This key is reserved for a venue type format - please use something different.',       // TODO: translate
     'min_password_length_string' => 'Hasło jest za krótkie! Hasło powinno posiadać minimum %d znaków!',
     'AJAX_Auth_Failure' => 'Nie udało się autoryzować operacji. Możliwe, że istnieje problem z konfiguracją serwera.',
     'Maps_API_Key_Warning' => 'Wystąpił problem z kluczem Google Maps API.',

--- a/main_server/local_server/server_admin/lang/pt/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/pt/server_admin_strings.inc.php
@@ -319,6 +319,7 @@ $comdef_server_admin_strings = array('server_admin_disclosure' => 'Administraç�
     'format_editor_delete_button_confirm' => 'Tem certeza que deseja apagar esse Formato de Reunião?',
     'format_editor_delete_button_confirm_perm' => 'Esse formato será apagado permanentemente!',
     'format_editor_missing_key' => 'This format should have an entry for every language (at least a key).',   // TODO: translate
+    'format_editor_reserved_key' => 'This key is reserved for a venue type format - please use something different.',       // TODO: translate
     'min_password_length_string' => 'Senha muito curta! Ela tem que ter no mínimo %d caracteres!',
     'AJAX_Auth_Failure' => 'Falha de autorização para essa ação. Falha de configuração do servidor.',
     'Maps_API_Key_Warning' => 'Há um problema com a chave da API do Google Maps.',

--- a/main_server/local_server/server_admin/lang/ru/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/ru/server_admin_strings.inc.php
@@ -324,6 +324,7 @@ $comdef_server_admin_strings = array('server_admin_disclosure' => 'Админи�
     'format_editor_delete_button_confirm' => 'Вы уверены, что хотите удалить этот формат?',
     'format_editor_delete_button_confirm_perm' => 'Этот формат будет удален навсегда!',
     'format_editor_missing_key' => 'This format should have an entry for every language (at least a key).',   // TODO: translate
+    'format_editor_reserved_key' => 'This key is reserved for a venue type format - please use something different.',       // TODO: translate
     'min_password_length_string' => 'Пароль слишком короткий! Длина должна быть не менее % d символов!',
     'AJAX_Auth_Failure' => 'Авторизация не удалась для этой операции. Может быть проблема с конфигурацией сервера.',
     'Maps_API_Key_Warning' => 'Возникла проблема с ключом API Google Maps.',

--- a/main_server/local_server/server_admin/lang/sv/server_admin_strings.inc.php
+++ b/main_server/local_server/server_admin/lang/sv/server_admin_strings.inc.php
@@ -326,6 +326,7 @@ $comdef_server_admin_strings = array(
     'format_editor_delete_button_confirm' => 'är du säker på att du vill kassera detta mötesformat?',
     'format_editor_delete_button_confirm_perm' => 'Mötesformatet kommer kasseras permanent!',
     'format_editor_missing_key' => 'This format should have an entry for every language (at least a key).',   // TODO: translate
+    'format_editor_reserved_key' => 'This key is reserved for a venue type format - please use something different.',       // TODO: translate
     'min_password_length_string' => 'Lösenordet måste vara minst %d tecken långt!',
     'AJAX_Auth_Failure' => 'Tillträde nekas. Det kan vara problem med serverinställningar.',
     'Maps_API_Key_Warning' => 'There is a problem with the Google Maps API Key.',


### PR DESCRIPTION
Without this check, we could end up with another format in English with one of the reserved keys HY, TC, or VM, potentially leading to the UI not being able to identify which one was the venue type format.