### PR TITLE
add php version to server info

### DIFF
--- a/main_server/client_interface/csv/csv.php
+++ b/main_server/client_interface/csv/csv.php
@@ -1136,6 +1136,7 @@ function GetServerInfo()
     $availableFields = "";
     $keys = c_comdef_meeting::GetFullTemplate();
     $meeting_time_zones_enabled = $localStrings['meeting_time_zones_enabled'] ? '1' : '0';
+    $phpVersion = phpversion();
     
     foreach ($keys as $key) {
         if (($key['visibility'] != 1) && ($key['key'] != 'published') && ($key['key'] != 'shared_group_id_bigint')) {
@@ -1147,12 +1148,12 @@ function GetServerInfo()
         }
     }
 
-    $ret = '"version","versionInt","langs","nativeLang","centerLongitude","centerLatitude","centerZoom","defaultDuration","regionBias","charSet","distanceUnits","semanticAdmin","emailEnabled","emailIncludesServiceBodies","changesPerMeeting","meeting_states_and_provinces","meeting_counties_and_sub_provinces","available_keys","google_api_key","dbVersion","dbPrefix","meeting_time_zones_enabled"'."\n";
+    $ret = '"version","versionInt","langs","nativeLang","centerLongitude","centerLatitude","centerZoom","defaultDuration","regionBias","charSet","distanceUnits","semanticAdmin","emailEnabled","emailIncludesServiceBodies","changesPerMeeting","meeting_states_and_provinces","meeting_counties_and_sub_provinces","available_keys","google_api_key","dbVersion","dbPrefix","meeting_time_zones_enabled","phpVersion"'."\n";
     $ret .= '"'.$version_string.'","'.strval($version_num).'","'.$lang_string.'","'.$default_lang.'",';
     $ret .= '"'.strval($localStrings['search_spec_map_center']['longitude']).'","'.strval($localStrings['search_spec_map_center']['latitude']).'",';
     $ret .= '"'.strval($localStrings['search_spec_map_center']['zoom']).'","'.$localStrings['default_duration_time'].'",';
     $ret .= '"'.$localStrings['region_bias'].'","'.$localStrings['charset'].'","'.$localStrings['dist_units'].'","'.$canAdmin.'",';
-    $ret .= '"'.$canEmail.'","'.$includeServiceBodiesOnEmails.'","'.$changeDepth.'","'.implode(',', $localStrings['meeting_states_and_provinces']).'","'.implode(',', $localStrings['meeting_counties_and_sub_provinces']).'","'.str_replace('"', '\"', $availableFields).',root_server_uri,format_shared_id_list","'.$localStrings['google_api_key'].'","'.$dbVersion.'","'.$localStrings['dbPrefix'].'","'.$meeting_time_zones_enabled.'"';
+    $ret .= '"'.$canEmail.'","'.$includeServiceBodiesOnEmails.'","'.$changeDepth.'","'.implode(',', $localStrings['meeting_states_and_provinces']).'","'.implode(',', $localStrings['meeting_counties_and_sub_provinces']).'","'.str_replace('"', '\"', $availableFields).',root_server_uri,format_shared_id_list","'.$localStrings['google_api_key'].'","'.$dbVersion.'","'.$localStrings['dbPrefix'].'","'.$meeting_time_zones_enabled.'","'.$phpVersion.'"';
     
     return $ret;
 }


### PR DESCRIPTION
Should help us gather data as we deprecate php versions.

```
[
  {
    "version": "2.16.4",
    "versionInt": "2016004",
    "langs": "en,de,dk,es,fa,fr,it,pl,pt,ru,sv",
    "nativeLang": "en",
    "centerLongitude": "-79.793701171875",
    "centerLatitude": "36.065752051707",
    "centerZoom": "10",
    "defaultDuration": "1:00:00",
    "regionBias": "us",
    "charSet": "UTF-8",
    "distanceUnits": "mi",
    "semanticAdmin": "1",
    "emailEnabled": "0",
    "emailIncludesServiceBodies": "0",
    "changesPerMeeting": "5",
    "meeting_states_and_provinces": "",
    "meeting_counties_and_sub_provinces": "",
    "available_keys": "id_bigint,worldid_mixed,service_body_bigint,weekday_tinyint,venue_type,start_time,duration_time,time_zone,formats,lang_enum,longitude,latitude,meeting_name,location_text,location_info,location_street,location_city_subsection,location_neighborhood,location_municipality,location_sub_province,location_province,location_postal_code_1,location_nation,comments,zone,train_lines,bus_lines,phone_meeting_number,virtual_meeting_link,virtual_meeting_additional_info,root_server_uri,format_shared_id_list",
    "google_api_key": "AIzaSyDqUE365P3yj6LVxweND4xRV-MNkq0EE68",
    "dbVersion": "21",
    "dbPrefix": "na",
    "meeting_time_zones_enabled": "0",
    "phpVersion": "7.2.24-0ubuntu0.18.04.10"
  }
]
```