### PR TITLE
Update dependencies, deprecate PHP 7.2, support PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-- '7.1'
+- '7.3'
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For instructions on installing the root server, see [Installing a New Root Serve
     - `&venue_types=-1` will exclude all In-Person meetings.
 - Added a new `key_strings` filter to `GetFormats`. This has also been implemented in tomato, and will allow crouton to make more efficient queries.
   - Example: `&key_strings[]=TC&key_strings[]=VM&key_strings[]=HY&lang_enum=en`
+- Dropped support for PHP 7.2.
 
 ***Version 2.16.3* ** *- October 27, 2021*
 - Fix bug in code that lets NAWS indicate they have processed a deleted meeting, so that you don't need to be logged in as the serveradmin for it to work

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For instructions on installing the root server, see [Installing a New Root Serve
 ***Version 2.16.4* ** *- UNRELEASED*
 - Added a new `parents=1` parameter to `GetServiceBodies`. When supplied with `services[]=x` filters, all parent service bodies will be returned.
 - Exposed `venue_type` in meeting search results.
-- Added a new `venue_types` filter to `GetSearchResults`. This works like the `weekdays` and `services` filters, where a passing a positive integer will include a Venue Type and a negative integer will exclude a Venue Type.
+- Added a new `venue_types` filter to `GetSearchResults`. This works like the `weekdays` and `services` filters, where passing a positive integer will include a Venue Type and a negative integer will exclude a Venue Type.
   - Filter Values
     - In-Person is `1`
     - Virtual is `2`

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For instructions on installing the root server, see [Installing a New Root Serve
     - `&venue_types=-1` will exclude all In-Person meetings.
 - Added a new `key_strings` filter to `GetFormats`. This has also been implemented in tomato, and will allow crouton to make more efficient queries.
   - Example: `&key_strings[]=TC&key_strings[]=VM&key_strings[]=HY&lang_enum=en`
-- Dropped support for PHP 7.2.
+- Dropped support for PHP 7.2, added support for PHP 8.0.
 
 ***Version 2.16.3* ** *- October 27, 2021*
 - Fix bug in code that lets NAWS indicate they have processed a deleted meeting, so that you don't need to be logged in as the serveradmin for it to work

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
         "vendor-dir": "main_server/vendor"
     },
     "require": {
-        "phpoffice/phpspreadsheet": "1.8.2"
+        "phpoffice/phpspreadsheet": "1.19.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,84 +4,161 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e8178ff694a77c014e11ad322343b24",
+    "content-hash": "bd4a1493553eac4837cb8db7252f8c49",
     "packages": [
         {
-            "name": "markbaker/complex",
-            "version": "1.4.7",
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.13.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/MarkBaker/PHPComplex.git",
-                "reference": "1ea674a8308baf547cbcbd30c5fcd6d301b7c000"
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "08e27c97e4c6ed02f37c5b2b20488046c8d90d75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MarkBaker/PHPComplex/zipball/1ea674a8308baf547cbcbd30c5fcd6d301b7c000",
-                "reference": "1ea674a8308baf547cbcbd30c5fcd6d301b7c000",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/08e27c97e4c6ed02f37c5b2b20488046c8d90d75",
+                "reference": "08e27c97e4c6ed02f37c5b2b20488046c8d90d75",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6.0|^7.0.0"
+                "php": ">=5.2"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
-                "phpcompatibility/php-compatibility": "^8.0",
-                "phpdocumentor/phpdocumentor": "2.*",
-                "phploc/phploc": "2.*",
-                "phpmd/phpmd": "2.*",
-                "phpunit/phpunit": "^4.8.35|^5.4.0",
-                "sebastian/phpcpd": "2.*",
-                "squizlabs/php_codesniffer": "^3.3.0"
+                "simpletest/simpletest": "dev-master#72de02a7b80c6bb8864ef9bf66d41d2f58f826bd"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ],
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "support": {
+                "issues": "https://github.com/ezyang/htmlpurifier/issues",
+                "source": "https://github.com/ezyang/htmlpurifier/tree/master"
+            },
+            "time": "2020-06-29T00:56:53+00:00"
+        },
+        {
+            "name": "maennchen/zipstream-php",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maennchen/ZipStream-PHP.git",
+                "reference": "c4c5803cc1f93df3d2448478ef79394a5981cc58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/c4c5803cc1f93df3d2448478ef79394a5981cc58",
+                "reference": "c4c5803cc1f93df3d2448478ef79394a5981cc58",
+                "shasum": ""
+            },
+            "require": {
+                "myclabs/php-enum": "^1.5",
+                "php": ">= 7.1",
+                "psr/http-message": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "require-dev": {
+                "ext-zip": "*",
+                "guzzlehttp/guzzle": ">= 6.3",
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpunit": ">= 7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZipStream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paul Duncan",
+                    "email": "pabs@pablotron.org"
+                },
+                {
+                    "name": "Jonatan Männchen",
+                    "email": "jonatan@maennchen.ch"
+                },
+                {
+                    "name": "Jesse Donat",
+                    "email": "donatj@gmail.com"
+                },
+                {
+                    "name": "András Kolesár",
+                    "email": "kolesar@kolesar.hu"
+                }
+            ],
+            "description": "ZipStream is a library for dynamically streaming dynamic zip files from PHP without writing to the disk at all on the server.",
+            "keywords": [
+                "stream",
+                "zip"
+            ],
+            "support": {
+                "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/zipstream",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2020-05-30T13:11:16+00:00"
+        },
+        {
+            "name": "markbaker/complex",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPComplex.git",
+                "reference": "ab8bc271e404909db09ff2d5ffa1e538085c0f22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPComplex/zipball/ab8bc271e404909db09ff2d5ffa1e538085c0f22",
+                "reference": "ab8bc271e404909db09ff2d5ffa1e538085c0f22",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.3",
+                "squizlabs/php_codesniffer": "^3.4"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "Complex\\": "classes/src/"
-                },
-                "files": [
-                    "classes/src/functions/abs.php",
-                    "classes/src/functions/acos.php",
-                    "classes/src/functions/acosh.php",
-                    "classes/src/functions/acot.php",
-                    "classes/src/functions/acoth.php",
-                    "classes/src/functions/acsc.php",
-                    "classes/src/functions/acsch.php",
-                    "classes/src/functions/argument.php",
-                    "classes/src/functions/asec.php",
-                    "classes/src/functions/asech.php",
-                    "classes/src/functions/asin.php",
-                    "classes/src/functions/asinh.php",
-                    "classes/src/functions/atan.php",
-                    "classes/src/functions/atanh.php",
-                    "classes/src/functions/conjugate.php",
-                    "classes/src/functions/cos.php",
-                    "classes/src/functions/cosh.php",
-                    "classes/src/functions/cot.php",
-                    "classes/src/functions/coth.php",
-                    "classes/src/functions/csc.php",
-                    "classes/src/functions/csch.php",
-                    "classes/src/functions/exp.php",
-                    "classes/src/functions/inverse.php",
-                    "classes/src/functions/ln.php",
-                    "classes/src/functions/log2.php",
-                    "classes/src/functions/log10.php",
-                    "classes/src/functions/negative.php",
-                    "classes/src/functions/pow.php",
-                    "classes/src/functions/rho.php",
-                    "classes/src/functions/sec.php",
-                    "classes/src/functions/sech.php",
-                    "classes/src/functions/sin.php",
-                    "classes/src/functions/sinh.php",
-                    "classes/src/functions/sqrt.php",
-                    "classes/src/functions/tan.php",
-                    "classes/src/functions/tanh.php",
-                    "classes/src/functions/theta.php",
-                    "classes/src/operations/add.php",
-                    "classes/src/operations/subtract.php",
-                    "classes/src/operations/multiply.php",
-                    "classes/src/operations/divideby.php",
-                    "classes/src/operations/divideinto.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -99,58 +176,44 @@
                 "complex",
                 "mathematics"
             ],
-            "time": "2018-10-13T23:28:42+00:00"
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPComplex/issues",
+                "source": "https://github.com/MarkBaker/PHPComplex/tree/3.0.1"
+            },
+            "time": "2021-06-29T15:32:53+00:00"
         },
         {
             "name": "markbaker/matrix",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MarkBaker/PHPMatrix.git",
-                "reference": "6ea97472b5baf12119b4f31f802835b820dd6d64"
+                "reference": "c66aefcafb4f6c269510e9ac46b82619a904c576"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MarkBaker/PHPMatrix/zipball/6ea97472b5baf12119b4f31f802835b820dd6d64",
-                "reference": "6ea97472b5baf12119b4f31f802835b820dd6d64",
+                "url": "https://api.github.com/repos/MarkBaker/PHPMatrix/zipball/c66aefcafb4f6c269510e9ac46b82619a904c576",
+                "reference": "c66aefcafb4f6c269510e9ac46b82619a904c576",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6.0|^7.0.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
-                "phpcompatibility/php-compatibility": "^8.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "phpcompatibility/php-compatibility": "^9.0",
                 "phpdocumentor/phpdocumentor": "2.*",
-                "phploc/phploc": "2.*",
+                "phploc/phploc": "^4.0",
                 "phpmd/phpmd": "2.*",
-                "phpunit/phpunit": "^4.8.35|^5.4.0",
-                "sebastian/phpcpd": "2.*",
-                "squizlabs/php_codesniffer": "^3.3.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.3",
+                "sebastian/phpcpd": "^4.0",
+                "squizlabs/php_codesniffer": "^3.4"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "Matrix\\": "classes/src/"
-                },
-                "files": [
-                    "classes/src/functions/adjoint.php",
-                    "classes/src/functions/antidiagonal.php",
-                    "classes/src/functions/cofactors.php",
-                    "classes/src/functions/determinant.php",
-                    "classes/src/functions/diagonal.php",
-                    "classes/src/functions/identity.php",
-                    "classes/src/functions/inverse.php",
-                    "classes/src/functions/minors.php",
-                    "classes/src/functions/trace.php",
-                    "classes/src/functions/transpose.php",
-                    "classes/src/operations/add.php",
-                    "classes/src/operations/directsum.php",
-                    "classes/src/operations/subtract.php",
-                    "classes/src/operations/multiply.php",
-                    "classes/src/operations/divideby.php",
-                    "classes/src/operations/divideinto.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -159,7 +222,7 @@
             "authors": [
                 {
                     "name": "Mark Baker",
-                    "email": "mark@lange.demon.co.uk"
+                    "email": "mark@demon-angel.eu"
                 }
             ],
             "description": "PHP Class for working with matrices",
@@ -169,20 +232,84 @@
                 "matrix",
                 "vector"
             ],
-            "time": "2018-11-04T22:12:12+00:00"
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPMatrix/issues",
+                "source": "https://github.com/MarkBaker/PHPMatrix/tree/3.0.0"
+            },
+            "time": "2021-07-01T19:01:15+00:00"
         },
         {
-            "name": "phpoffice/phpspreadsheet",
-            "version": "1.8.2",
+            "name": "myclabs/php-enum",
+            "version": "1.8.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "0c1346a1956347590b7db09533966307d20cb7cc"
+                "url": "https://github.com/myclabs/php-enum.git",
+                "reference": "b942d263c641ddb5190929ff840c68f78713e937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/0c1346a1956347590b7db09533966307d20cb7cc",
-                "reference": "0c1346a1956347590b7db09533966307d20cb7cc",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/b942d263c641ddb5190929ff840c68f78713e937",
+                "reference": "b942d263c641ddb5190929ff840c68f78713e937",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "1.*",
+                "vimeo/psalm": "^4.6.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MyCLabs\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP Enum contributors",
+                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
+                }
+            ],
+            "description": "PHP Enum implementation",
+            "homepage": "http://github.com/myclabs/php-enum",
+            "keywords": [
+                "enum"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/php-enum/issues",
+                "source": "https://github.com/myclabs/php-enum/tree/1.8.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-05T08:18:36+00:00"
+        },
+        {
+            "name": "phpoffice/phpspreadsheet",
+            "version": "1.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
+                "reference": "a9ab55bfae02eecffb3df669a2e19ba0e2f04bbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/a9ab55bfae02eecffb3df669a2e19ba0e2f04bbf",
+                "reference": "a9ab55bfae02eecffb3df669a2e19ba0e2f04bbf",
                 "shasum": ""
             },
             "require": {
@@ -199,27 +326,33 @@
                 "ext-xmlwriter": "*",
                 "ext-zip": "*",
                 "ext-zlib": "*",
-                "markbaker/complex": "^1.4",
-                "markbaker/matrix": "^1.1",
-                "php": "^5.6|^7.0",
+                "ezyang/htmlpurifier": "^4.13",
+                "maennchen/zipstream-php": "^2.1",
+                "markbaker/complex": "^3.0",
+                "markbaker/matrix": "^3.0",
+                "php": "^7.2 || ^8.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
                 "psr/simple-cache": "^1.0"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1.0.0",
-                "dompdf/dompdf": "^0.8.0",
-                "friendsofphp/php-cs-fixer": "@stable",
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "dompdf/dompdf": "^1.0",
+                "friendsofphp/php-cs-fixer": "^2.18",
                 "jpgraph/jpgraph": "^4.0",
-                "mpdf/mpdf": "^7.0.0",
-                "phpcompatibility/php-compatibility": "^8.0",
-                "phpunit/phpunit": "^5.7",
-                "squizlabs/php_codesniffer": "^3.3",
-                "tecnickcom/tcpdf": "^6.2"
+                "mpdf/mpdf": "^8.0",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpstan/phpstan": "^0.12.82",
+                "phpstan/phpstan-phpunit": "^0.12.18",
+                "phpunit/phpunit": "^8.5",
+                "squizlabs/php_codesniffer": "^3.5",
+                "tecnickcom/tcpdf": "^6.3"
             },
             "suggest": {
-                "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
+                "dompdf/dompdf": "Option for rendering PDF with PDF Writer (doesn't yet support PHP8)",
                 "jpgraph/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
                 "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
-                "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer"
+                "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer (doesn't yet support PHP8)"
             },
             "type": "library",
             "autoload": {
@@ -229,15 +362,9 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-2.1-or-later"
+                "MIT"
             ],
             "authors": [
-                {
-                    "name": "Erik Tilt"
-                },
-                {
-                    "name": "Adrien Crivelli"
-                },
                 {
                     "name": "Maarten Balliauw",
                     "homepage": "https://blog.maartenballiauw.be"
@@ -249,6 +376,12 @@
                 {
                     "name": "Franck Lefevre",
                     "homepage": "https://rootslabs.net"
+                },
+                {
+                    "name": "Erik Tilt"
+                },
+                {
+                    "name": "Adrien Crivelli"
                 }
             ],
             "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
@@ -263,7 +396,171 @@
                 "xls",
                 "xlsx"
             ],
-            "time": "2019-07-08T21:21:25+00:00"
+            "support": {
+                "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.19.0"
+            },
+            "time": "2021-10-31T15:09:20+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/master"
+            },
+            "time": "2019-04-30T12:38:16+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -311,7 +608,90 @@
                 "psr-16",
                 "simple-cache"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/master"
+            },
             "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T12:26:48+00:00"
         }
     ],
     "packages-dev": [
@@ -449,16 +829,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.2",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
@@ -496,7 +876,12 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-04-10T23:49:02+00:00"
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-10-11T04:00:11+00:00"
         }
     ],
     "aliases": [],

--- a/docker/Dockerfile-bmlt
+++ b/docker/Dockerfile-bmlt
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lts/ubuntu:bionic
+FROM public.ecr.aws/lts/ubuntu:focal
 
 ENV TZ=America/New_York
 
@@ -9,7 +9,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
     apache2 \
     libapache2-mod-php \
     php-mysql \
-    php7.2-xml \
+    php-xml \
     php-curl \
     php-gd \
     php-zip \

--- a/docker/Dockerfile-bmltdebug
+++ b/docker/Dockerfile-bmltdebug
@@ -1,12 +1,12 @@
 FROM public.ecr.aws/t5y4k5q3/bmlt-root-server:latest
 
-ENV PHP_INI_PATH /etc/php/7.2/apache2/php.ini
+ENV PHP_INI_PATH /etc/php/7.4/apache2/php.ini
 ENV PHP_XDEBUG_ENABLED: 1
 
 RUN apt-get update \
     && apt-get -yqq install \
-    php7.2-dev \
-    php7.2-xdebug
+    php-dev \
+    php-xdebug
 
 RUN echo "zend_extension=$(find /usr/lib/php/ -name xdebug.so)" >> ${PHP_INI_PATH} \
     && echo "xdebug.remote_port=10000" >> ${PHP_INI_PATH} \

--- a/main_server/client_interface/contact.php
+++ b/main_server/client_interface/contact.php
@@ -67,9 +67,9 @@ if (preg_match("/localhost/", $_SERVER['SERVER_NAME'])) {
 
     \returns a Boolean. TRUE if the message appears to be spam.
 */
-function analyzeFromLine( $inFrom ///< The message from line as a text string.
-                        )
-{
+function analyzeFromLine(
+    $inFrom ///< The message from line as a text string.
+) {
     $inFrom = strtolower($inFrom);
     
     $ret = !((false == strpos($inFrom, "\r")) && (false == strpos($inFrom, "\n")) && (false == strpos($inFrom, ";")) && (false == strpos($inFrom, "to:")) && (false == strpos($inFrom, "cc:")) && (false == strpos($inFrom, "bc:")));
@@ -84,9 +84,9 @@ function analyzeFromLine( $inFrom ///< The message from line as a text string.
 
     \returns a Boolean. TRUE if the message appears to be spam.
 */
-function analyzeMessageContent( $inMessage ///< The message as a text string.
-                                )
-{
+function analyzeMessageContent(
+    $inMessage ///< The message as a text string.
+) {
     $ret = false;
     $count = 0;
     
@@ -110,9 +110,9 @@ function analyzeMessageContent( $inMessage ///< The message as a text string.
 /** \brief This analyzes email address (or a list of them), and returns TRUE if they are OK (as formatted).
     \returns a Boolean. TRUE if the emails are OK.
 */
-function isValidEmailAddress(  $in_test_address    ///< The email address (or a list or array) to be checked.
-                                )
-{
+function isValidEmailAddress(
+    $in_test_address    ///< The email address (or a list or array) to be checked.
+) {
     $valid = false;
     if (isset($in_test_address)) {
         if (!is_array($in_test_address)) {

--- a/main_server/client_interface/csv/c_comdef_meeting_search_manager.class.php
+++ b/main_server/client_interface/csv/c_comdef_meeting_search_manager.class.php
@@ -300,9 +300,9 @@ class c_comdef_meeting_search_manager
     /** \brief Sets the sort by distance flag.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function SetSortByDistance( $in_sort_search_by_distance = false    ///< A Boolean. False is default.
-                                )
-    {
+    public function SetSortByDistance(
+        $in_sort_search_by_distance = false    ///< A Boolean. False is default.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $this->_sort_search_by_distance = ($in_sort_search_by_distance != false);
     }
@@ -359,9 +359,9 @@ class c_comdef_meeting_search_manager
         \returns a boolean. If the operation was successful, it is true. False otherwise.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function SetResultsPerPage( $in_results_per_page    ///< A positive integer. If it is 0, then all results will be returned in one page.
-                                )
-    {
+    public function SetResultsPerPage(
+        $in_results_per_page    ///< A positive integer. If it is 0, then all results will be returned in one page.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = false;
         
@@ -483,9 +483,9 @@ class c_comdef_meeting_search_manager
         object, containing a subset of the meetings to fill this one page.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function GetPageOfResults( $in_page_no = 1  ///< A positive integer. This should be 1 to $this->GetNumberOfPages() (1-based)
-                            )
-    {
+    public function GetPageOfResults(
+        $in_page_no = 1  ///< A positive integer. This should be 1 to $this->GetNumberOfPages() (1-based)
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         if ($in_page_no < 1) {  // Can't be less than 1.
             $in_page_no = 1;
@@ -728,9 +728,9 @@ class c_comdef_meeting_search_manager
         is in miles.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function GetRadius( $in_miles = false  ///< A boolean. If true, the returned value will be in miles. Otherwise, it is returned in kilometers.
-                        )
-    {
+    public function GetRadius(
+        $in_miles = false  ///< A boolean. If true, the returned value will be in miles. Otherwise, it is returned in kilometers.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         return  $in_miles ? ($this->_search_radius / 1.609344) : $this->_search_radius;
     }
@@ -778,13 +778,13 @@ class c_comdef_meeting_search_manager
     /** \brief Sets the search for published value
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function SetPublished( $in_published_search
-// The value to set. It can be:
-                                                        //  - -1    Search for ONLY unpublished meetings
-                                                        //  -  0    Search for published and unpublished meetings.
-                                                        //  -  1    Search for ONLY published meetings.
-                            )
-    {
+    public function SetPublished(
+        $in_published_search
+        // The value to set. It can be:
+        //  - -1    Search for ONLY unpublished meetings
+        //  -  0    Search for published and unpublished meetings.
+        //  -  1    Search for ONLY published meetings.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $this->_published_search = $in_published_search;
     }
@@ -819,9 +819,9 @@ class c_comdef_meeting_search_manager
     /** \brief Set a maximum end time.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function SetEndTime( $in_ends_before       ///< An epoch time, defining that the meeting must end no later than this.
-                            )
-    {
+    public function SetEndTime(
+        $in_ends_before       ///< An epoch time, defining that the meeting must end no later than this.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $this->_end_before = $in_ends_before;
     }
@@ -936,9 +936,9 @@ class c_comdef_meeting_search_manager
     /** \brief Set the current search string.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function SetMeetingIDArray( $in_meeting_id_array   ///< An array of positive integers. These are the IDs of individual meetings to find.
-                                )
-    {
+    public function SetMeetingIDArray(
+        $in_meeting_id_array   ///< An array of positive integers. These are the IDs of individual meetings to find.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $this->_meeting_id_array = $in_meeting_id_array;
     }
@@ -1120,9 +1120,9 @@ class c_comdef_meeting_search_manager
         instance of c_comdef_search_results).
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function GetSearchResults_Obj( $in_new_search = false   ///< If this is set to true, the search is done anew.
-                                    )
-    {
+    public function GetSearchResults_Obj(
+        $in_new_search = false   ///< If this is set to true, the search is done anew.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         // See if we need to make a new search. Only the root can do a new search.
         if ((null == $this->_my_root) && (true == $in_new_search) || (null == $this->_search_results)) {
@@ -1316,9 +1316,9 @@ class c_comdef_meeting_search_manager
         beyond that.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function SetSortDepth( $in_new_depth = 0   ///< A positive integer. If nothing is provided, we set to endless (0).
-                            )
-    {
+    public function SetSortDepth(
+        $in_new_depth = 0   ///< A positive integer. If nothing is provided, we set to endless (0).
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         // Only the root can do this.
         if (null == $this->_my_root) {
@@ -1531,9 +1531,9 @@ class c_comdef_meeting_search_manager
         \returns a new (not reference) c_comdef_meeting instance. Null if it fails.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public static function GetSingleMeetingByID( $in_id   ///< An integer. The ID of the meeting.
-                                        )
-    {
+    public static function GetSingleMeetingByID(
+        $in_id   ///< An integer. The ID of the meeting.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         return c_comdef_server::GetOneMeeting($in_id);
     }
@@ -1550,9 +1550,9 @@ class c_comdef_meeting_search_manager
         Null if it fails.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public static function GetMultipleMeetingsByID( $in_id_array  ///< An array of integers. The IDs of the meetings.
-                                            )
-    {
+    public static function GetMultipleMeetingsByID(
+        $in_id_array  ///< An array of integers. The IDs of the meetings.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
         

--- a/main_server/client_interface/csv/common_search.inc.php
+++ b/main_server/client_interface/csv/common_search.inc.php
@@ -560,9 +560,9 @@ function SetUpSearch(
 
     \returns an array of integers.
 */
-function GetAllContainedServiceBodyIDs( $in_parent_id = 0  ///< This is the ID of the top Service body (will not be included in the reponse).
-                                        )
-{
+function GetAllContainedServiceBodyIDs(
+    $in_parent_id = 0  ///< This is the ID of the top Service body (will not be included in the reponse).
+) {
     $in_parent_id = intval($in_parent_id);
     $ret = array( $in_parent_id );
     
@@ -626,9 +626,9 @@ function BuildFormats(
 
     \returns a string, containing the HTML rendered by the function.
 */
-function BuildTown( $in_mtg_obj ///< A reference to an instance of c_comdef_meeting.
-                    )
-{
+function BuildTown(
+    $in_mtg_obj ///< A reference to an instance of c_comdef_meeting.
+) {
     $location_borough = c_comdef_htmlspecialchars(trim(stripslashes($in_mtg_obj->GetMeetingDataValue('location_city_subsection'))));
     $location_town = c_comdef_htmlspecialchars(trim(stripslashes($in_mtg_obj->GetMeetingDataValue('location_municipality'))));
     $location_neighborhood = c_comdef_htmlspecialchars(trim(stripslashes($in_mtg_obj->GetMeetingDataValue('location_neighborhood'))));
@@ -684,9 +684,9 @@ function BuildTime(
 
     \returns a string, containing the HTML rendered by the function.
 */
-function BuildLocation( $in_mtg_obj ///< A reference to an instance of c_comdef_meeting.
-                        )
-{
+function BuildLocation(
+    $in_mtg_obj ///< A reference to an instance of c_comdef_meeting.
+) {
     $ret = "";
     
     if ($in_mtg_obj instanceof c_comdef_meeting) {

--- a/main_server/client_interface/csv/csv.php
+++ b/main_server/client_interface/csv/csv.php
@@ -684,9 +684,9 @@ function CSVHandleNawsDump(
 
     \returns an associative array. Each main element will be one line, and each line will be an associative array of fields. If a field is not present in the line, it is not included.
 */
-function returnArrayFromCSV( $inCSVArray   ///< A array of CSV data, split as lines (each element is a single text line of CSV data). the first line is the header (array keys).
-)
-{
+function returnArrayFromCSV(
+    $inCSVArray   ///< A array of CSV data, split as lines (each element is a single text line of CSV data). the first line is the header (array keys).
+) {
     $ret = null;
     
     $desc_line = $inCSVArray[0];    // Get the field names.
@@ -1530,9 +1530,9 @@ function HandleNoServer()
 
     \returns a JSON string, with all the data in the CSV.
 */
-function TranslateToJSON( $in_csv_data ///< An array of CSV data, with the first element being the field names.
-                        )
-{
+function TranslateToJSON(
+    $in_csv_data ///< An array of CSV data, with the first element being the field names.
+) {
     $temp_keyed_array = array();
     $in_csv_data = explode("\n", $in_csv_data);
     $keys = array_shift($in_csv_data);
@@ -1571,9 +1571,9 @@ function TranslateToJSON( $in_csv_data ///< An array of CSV data, with the first
 
     \returns an XML string, with all the data in the CSV.
 */
-function TranslateToXML(   $in_csv_data        ///< An array of CSV data, with the first element being the field names.
-                        )
-{
+function TranslateToXML(
+    $in_csv_data        ///< An array of CSV data, with the first element being the field names.
+) {
     $temp_keyed_array = array();
     $in_csv_data = explode("\n", $in_csv_data);
     $keys = array_shift($in_csv_data);

--- a/main_server/client_interface/simple/index.php
+++ b/main_server/client_interface/simple/index.php
@@ -339,9 +339,9 @@ if ($server instanceof c_comdef_server) {
 
         \returns a string, containing the HTML rendered by the function.
     */
-    function BuildMeetingTime( $in_time ///< A string. The value of the time field.
-                                )
-    {
+    function BuildMeetingTime(
+        $in_time ///< A string. The value of the time field.
+    ) {
         $localized_strings = c_comdef_server::GetLocalStrings();
         
         $time = null;

--- a/main_server/local_server/install_wizard/installer_guts.php
+++ b/main_server/local_server/install_wizard/installer_guts.php
@@ -438,9 +438,9 @@ $default_lang = $lang;
 
     \returns a string, containing the element HTML.
 */
-function bmlt_create_next_prev_buttons( $in_section  ///< The page we are in. An integer.
-                                        )
-{
+function bmlt_create_next_prev_buttons(
+    $in_section  ///< The page we are in. An integer.
+) {
     global  $comdef_install_wizard_strings;
     $ret = '<div class="next_prev_container_div">';
     if ($in_section > 1) {

--- a/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -42,9 +42,9 @@ class c_comdef_admin_ajax_handler
     /*******************************************************************************************************//**
     \brief
     ***********************************************************************************************************/
-    public function __construct(  $in_http_vars   ///< The HTTP transaction parameters
-                        )
-    {
+    public function __construct(
+        $in_http_vars   ///< The HTTP transaction parameters
+    ) {
         $this->my_http_vars = $in_http_vars;
         $this->my_localized_strings = c_comdef_server::GetLocalStrings();
         $this->my_server = c_comdef_server::MakeServer();
@@ -426,9 +426,9 @@ class c_comdef_admin_ajax_handler
         \brief
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function HandleFormatChange(   $in_new_format_data     ///< A JSON string with the new format data.
-                                )
-    {
+    public function HandleFormatChange(
+        $in_new_format_data     ///< A JSON string with the new format data.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         if (c_comdef_server::IsUserServerAdmin(null, true)) {
             $json_tool = new PhpJsonXmlArrayStringInterchanger;
@@ -550,9 +550,9 @@ class c_comdef_admin_ajax_handler
         \brief
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function HandleDeleteFormat(   $in_format_shared_id    ///< The shared ID of the formats to delete.
-                                )
-    {
+    public function HandleDeleteFormat(
+        $in_format_shared_id    ///< The shared ID of the formats to delete.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         if (c_comdef_server::IsUserServerAdmin(null, true)) {
             $ret_data = '';
@@ -583,9 +583,9 @@ class c_comdef_admin_ajax_handler
         \brief
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function HandleUserCreate( $in_user_data   ///< A JSON object, containing the new User data.
-                                )
-    {
+    public function HandleUserCreate(
+        $in_user_data   ///< A JSON object, containing the new User data.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         if (c_comdef_server::IsUserServerAdmin(null, true)) {
             $json_tool = new PhpJsonXmlArrayStringInterchanger;
@@ -650,9 +650,9 @@ class c_comdef_admin_ajax_handler
         \brief
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function HandleUserChange( $in_user_data   ///< A JSON object, containing the new User data.
-                                )
-    {
+    public function HandleUserChange(
+        $in_user_data   ///< A JSON object, containing the new User data.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $isServerAdmin = c_comdef_server::IsUserServerAdmin(null, true);
         $isServiceBodyAdmin = c_comdef_server::IsUserServiceBodyAdmin(null, true);
@@ -794,9 +794,9 @@ class c_comdef_admin_ajax_handler
         \brief  This handles updating an existing Service body.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function HandleServiceBodyChange(  $in_service_body_data    ///< A JSON object, containing the new Service Body data.
-                                        )
-    {
+    public function HandleServiceBodyChange(
+        $in_service_body_data    ///< A JSON object, containing the new Service Body data.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $json_tool = new PhpJsonXmlArrayStringInterchanger;
         
@@ -855,9 +855,9 @@ class c_comdef_admin_ajax_handler
         \brief  This handles creating a new Service body.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function HandleServiceBodyCreate(  $in_service_body_data    ///< A JSON object, containing the new Service Body data.
-                                        )
-    {
+    public function HandleServiceBodyCreate(
+        $in_service_body_data    ///< A JSON object, containing the new Service Body data.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         if (c_comdef_server::IsUserServerAdmin(null, true)) {
             $json_tool = new PhpJsonXmlArrayStringInterchanger;
@@ -1092,9 +1092,9 @@ class c_comdef_admin_ajax_handler
         \brief  This handles updating an existing meeting, or adding a new one.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function HandleMeetingUpdate(  $in_meeting_data    ///< A JSON object, containing the new meeting data.
-                                )
-    {
+    public function HandleMeetingUpdate(
+        $in_meeting_data    ///< A JSON object, containing the new meeting data.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $json_tool = new PhpJsonXmlArrayStringInterchanger;
         
@@ -1437,9 +1437,9 @@ class c_comdef_admin_ajax_handler
         \returns a JSON string, with all the data in the CSV.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function TranslateToJSON( $in_csv_data ///< An array of CSV data, with the first element being the field names.
-                            )
-    {
+    public function TranslateToJSON(
+        $in_csv_data ///< An array of CSV data, with the first element being the field names.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $temp_keyed_array = array();
         $in_csv_data = explode("\n", $in_csv_data);

--- a/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -48,9 +48,9 @@ class c_comdef_admin_main_console
     /********************************************************************************************************//**
     \brief
     ************************************************************************************************************/
-    public function __construct(  $in_http_vars   ///< The HTTP transaction parameters
-                        )
-    {
+    public function __construct(
+        $in_http_vars   ///< The HTTP transaction parameters
+    ) {
         $this->my_http_vars = $in_http_vars;
         $this->my_localized_strings = c_comdef_server::GetLocalStrings();
         $this->my_server = c_comdef_server::MakeServer();
@@ -1135,9 +1135,9 @@ class c_comdef_admin_main_console
     \returns a string, containing the name.
     ************************************************************************************************************/
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function get_user_name_from_id($in_user_id  ///< The ID to look up.
-                                    )
-    {
+    public function get_user_name_from_id(
+        $in_user_id  ///< The ID to look up.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
         
@@ -1417,9 +1417,9 @@ class c_comdef_admin_main_console
     \brief Build the content for the Advanced Service Bodies section.
     ****************************************************************************************/
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function populate_service_bodies(  $in_id    ///< The ID of the Service body.
-                                      )
-    {
+    public function populate_service_bodies(
+        $in_id    ///< The ID of the Service body.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $service_body_content = '';
         $child_content = '';

--- a/main_server/local_server/server_admin/c_comdef_admin_xml_handler.class.php
+++ b/main_server/local_server/server_admin/c_comdef_admin_xml_handler.class.php
@@ -1592,9 +1592,9 @@ class c_comdef_admin_xml_handler
     \returns XML, containing the answer.
     ************************************************************************************************************/
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function process_service_body_info_request(    $in_service_body_id ///< The ID of the Service body being requested.
-                                                )
-    {
+    public function process_service_body_info_request(
+        $in_service_body_id ///< The ID of the Service body being requested.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = '';
         // Belt and suspenders. We need to make sure the user is authorized.
@@ -1847,9 +1847,9 @@ class c_comdef_admin_xml_handler
         \returns an XML string, with all the data in the CSV.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function TranslateCSVToXML(    $in_csv_data    ///< An array of CSV data, with the first element being the field names.
-                                )
-    {
+    public function TranslateCSVToXML(
+        $in_csv_data    ///< An array of CSV data, with the first element being the field names.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         require_once(dirname(dirname(dirname(__FILE__))).'/server/shared/Array2XML.php');
         $temp_keyed_array = array();

--- a/main_server/local_server/server_admin/c_comdef_login.php
+++ b/main_server/local_server/server_admin/c_comdef_login.php
@@ -231,9 +231,9 @@ function GetServerInfo()
 
     \returns a string, containing the form HTML.
 */
-function c_comdef_LoginForm(    &$in_server ///< A reference to an instance of c_comdef_server
-                                )
-{
+function c_comdef_LoginForm(
+    &$in_server ///< A reference to an instance of c_comdef_server
+) {
     include(dirname(dirname(dirname(__FILE__))).'/server/config/get-config.php');
 
     $http_vars = array_merge($_GET, $_POST);

--- a/main_server/server/c_comdef_server.class.php
+++ b/main_server/server/c_comdef_server.class.php
@@ -554,9 +554,9 @@ class c_comdef_server
                     Service bodies that are "owned" by this one.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function GetNestedServiceBodyArray( $in_id = 0 ///< The ID of the "top" Service body. If not supplied, we start at the top.
-                                        )
-    {
+    public function GetNestedServiceBodyArray(
+        $in_id = 0 ///< The ID of the "top" Service body. If not supplied, we start at the top.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret_array = null;
         
@@ -707,9 +707,9 @@ class c_comdef_server
         \returns an integer, with the ID of the new meeting. 0 If it fails.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public static function DuplicateMeetingID( $in_meeting_id ///< The ID of the meeting to be copied.
-                                        )
-    {
+    public static function DuplicateMeetingID(
+        $in_meeting_id ///< The ID of the meeting to be copied.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = 0;
         
@@ -733,9 +733,9 @@ class c_comdef_server
         \returns a reference to a c_comdef_meeting object, representing the new meeting. Null if it fails.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public static function DuplicateMeetingObj( $in_meeting_obj   ///< A reference to the meeting object to be copied.
-                                        )
-    {
+    public static function DuplicateMeetingObj(
+        $in_meeting_obj   ///< A reference to the meeting object to be copied.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $new_meeting =  null;
         
@@ -1160,9 +1160,9 @@ class c_comdef_server
         \returns a reference to a c_comdef_user object. Null if none.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public static function GetUserByLogin(    $in_login      ///< A string. The login ID.
-                                    )
-    {
+    public static function GetUserByLogin(
+        $in_login      ///< A string. The login ID.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
         
@@ -1205,9 +1205,9 @@ class c_comdef_server
         Null if it failed.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public static function GetCurrentUserObj($in_is_ajax = false  ///< If it's an AJAX handler, this is true.
-                                        )
-    {
+    public static function GetCurrentUserObj(
+        $in_is_ajax = false  ///< If it's an AJAX handler, this is true.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         include(dirname(__FILE__).'/config/get-config.php');
 
@@ -2376,9 +2376,9 @@ class c_comdef_server
         \returns a floating point number, with the number of Km per degree longitude at the given latitude..
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public static function getKmPerLonAtLat($dLatitude ///< The latitude (in degrees).
-                                    )
-    {
+    public static function getKmPerLonAtLat(
+        $dLatitude ///< The latitude (in degrees).
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         return 111.321 * cos(deg2rad($dLatitude));
     }
@@ -2666,9 +2666,9 @@ class c_comdef_server
             - 'time_zone_strings'               An array of time zone strings.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public static function GetLocalStrings( $in_lang_enum = null  ///< An enumeration string, indicating the language desired. If provided, it overrides all else.
-                                    )
-    {
+    public static function GetLocalStrings(
+        $in_lang_enum = null  ///< An enumeration string, indicating the language desired. If provided, it overrides all else.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         if (!is_array(c_comdef_server::$server_local_strings) || !count(c_comdef_server::$server_local_strings)) {
             // This will create the SINGLETON server if one does not yet exist.
@@ -3117,9 +3117,9 @@ class c_comdef_server
      be removed entirely.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public static function GetUserServiceBodies( $in_user = null   ///< The user to check. If not provided, the current user is checked.
-                                            )
-    {
+    public static function GetUserServiceBodies(
+        $in_user = null   ///< The user to check. If not provided, the current user is checked.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         if (!$in_user) {
             $in_user = self::GetCurrentUserObj();

--- a/main_server/server/classes/c_comdef_meeting.class.php
+++ b/main_server/server/classes/c_comdef_meeting.class.php
@@ -540,9 +540,9 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         \throws an exception if there is a problem.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public static function GetAddressDataItemKeys( $in_list = false   ///< If this is true, then the return is for the list view. If false, for the "More Details" screen.
-                                            )
-    {
+    public static function GetAddressDataItemKeys(
+        $in_list = false   ///< If this is true, then the return is for the list view. If false, for the "More Details" screen.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
         
@@ -582,9 +582,9 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         \throws an exception if there is a problem.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public static function GetAddressDataItemBuilder( $in_list = false    ///< If this is true, then the return is for the list view. If false, for the "More Details" screen.
-                                                )
-    {
+    public static function GetAddressDataItemBuilder(
+        $in_list = false    ///< If this is true, then the return is for the list view. If false, for the "More Details" screen.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
         
@@ -1060,9 +1060,9 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         \returns a reference to the value of the requested element. Null if the element is not there.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function GetMeetingDataValue( $in_key   ///< A string. This is the key in the data array.
-                                )
-    {
+    public function GetMeetingDataValue(
+        $in_key   ///< A string. This is the key in the data array.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
         
@@ -1087,9 +1087,9 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         \returns a boolean. True, if the data item is hidden from normal users.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function IsItemHidden( $in_key ///< A string. This is the key in the data array.
-                            )
-    {
+    public function IsItemHidden(
+        $in_key ///< A string. This is the key in the data array.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = ($in_key == 'email_contact');
         
@@ -1108,9 +1108,9 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         \returns a string. Null if the element is not there.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function GetMeetingDataPrompt( $in_key  ///< A string. This is the key in the data array.
-                                    )
-    {
+    public function GetMeetingDataPrompt(
+        $in_key  ///< A string. This is the key in the data array.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
         
@@ -1180,9 +1180,9 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
     /** \brief Accessor - Sets the meeting's published status.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function SetPublished( $in_published   ///< A boolean. True if the meeting is published.
-                            )
-    {
+    public function SetPublished(
+        $in_published   ///< A boolean. True if the meeting is published.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         if (!$this->IsCopy()) { // Can't publish copies.
             $this->_my_meeting_data['published'] = (intval($in_published) != 0) ? 1 : 0;
@@ -1261,9 +1261,9 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         \returns a boolean, which is true if the address was set correctly.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function SetEmailContact(   $in_email_contact   ///< A string. The contact email address.
-                                )
-    {
+    public function SetEmailContact(
+        $in_email_contact   ///< A string. The contact email address.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = false;
         
@@ -1293,9 +1293,9 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         \returns an integer, which is the previous ID of the Service Body for this meeting.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function SetServiceBodyID(  $in_service_body_id ///< An integer, the ID of the new Service Body for this meeting.
-                                )
-    {
+    public function SetServiceBodyID(
+        $in_service_body_id ///< An integer, the ID of the new Service Body for this meeting.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = $this->_my_meeting_data['service_body_bigint'];
         
@@ -1434,9 +1434,9 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         \returns a string, containing the meeting's address in easily-readable form.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function GetMeetingAddressString( $in_list = false  ///< If this is true, then the version returned will be for the list display. Default is false (The More Details display).
-                                    )
-    {
+    public function GetMeetingAddressString(
+        $in_list = false  ///< If this is true, then the version returned will be for the list display. Default is false (The More Details display).
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
         
@@ -1713,9 +1713,9 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         \returns a string, which is the contact email for this meeting
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function GetContactEmail( $in_recursive = false ///< If this is true, then the function will return a recursive result. Default is false.
-                            )
-    {
+    public function GetContactEmail(
+        $in_recursive = false ///< If this is true, then the function will return a recursive result. Default is false.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = trim($this->GetEmailContact());
         

--- a/main_server/server/classes/c_comdef_meetings.class.php
+++ b/main_server/server/classes/c_comdef_meetings.class.php
@@ -786,7 +786,7 @@ class c_comdef_meetings implements i_comdef_has_parent
             $ret = ($object_a->_distance_in_km < $object_b->_distance_in_km) ? -1 : 1;
             
             if (0 == $ret) {
-                $ret = $this::SortKernel($object_a, $object_b);
+                $ret = c_comdef_meetings::SortKernel($object_a, $object_b);
             }
         }
         

--- a/main_server/server/classes/c_comdef_service_body.class.php
+++ b/main_server/server/classes/c_comdef_service_body.class.php
@@ -619,9 +619,9 @@ class c_comdef_service_body extends t_comdef_world_type implements i_comdef_db_s
     /** \brief Accessor - set the contact email string.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function SetContactEmail( $in_email ///< A string. The email address to be set.
-                            )
-    {
+    public function SetContactEmail(
+        $in_email ///< A string. The email address to be set.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $this->_sb_meeting_email = $in_email;
     }
@@ -636,9 +636,9 @@ class c_comdef_service_body extends t_comdef_world_type implements i_comdef_db_s
         \returns a string, which is the contact email for this Service Body
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function GetContactEmail( $in_recursive = false ///< If this is true, then the function will return a recursive result. Default is false.
-                            )
-    {
+    public function GetContactEmail(
+        $in_recursive = false ///< If this is true, then the function will return a recursive result. Default is false.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = trim($this->_sb_meeting_email);
         
@@ -701,9 +701,9 @@ class c_comdef_service_body extends t_comdef_world_type implements i_comdef_db_s
         \returns a boolean. True if the user is an editor or principal user.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function IsUserInServiceBody( $in_user_object = null    ///< A reference to an instance of c_comdef_user. If null, the current user is checked.
-                                )
-    {
+    public function IsUserInServiceBody(
+        $in_user_object = null    ///< A reference to an instance of c_comdef_user. If null, the current user is checked.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = false;
         // We load the server user if one wasn't supplied.
@@ -740,9 +740,9 @@ class c_comdef_service_body extends t_comdef_world_type implements i_comdef_db_s
         \returns a boolean. True if the user is in the hierarchy (going up) of the Service Body.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function IsUserInServiceBodyHierarchy( $in_user_object = null   ///< A reference to an instance of c_comdef_user. If null, the current user is checked.
-                                            )
-    {
+    public function IsUserInServiceBodyHierarchy(
+        $in_user_object = null   ///< A reference to an instance of c_comdef_user. If null, the current user is checked.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = false;
         // We load the server user if one wasn't supplied.
@@ -928,9 +928,9 @@ class c_comdef_service_body extends t_comdef_world_type implements i_comdef_db_s
         \returns true, if the user is allowed to observe, false, otherwise.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function UserCanObserve(   $in_user_object = null  ///< A reference to a c_comdef_user object, for the user to be validated. If null, or not supplied, the server current user is tested.
-                                )
-    {
+    public function UserCanObserve(
+        $in_user_object = null  ///< A reference to a c_comdef_user object, for the user to be validated. If null, or not supplied, the server current user is tested.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = $this->UserCanEdit($in_user_object);  // First, see if we are able to edit this Service body. If so, then we're golden.
         

--- a/main_server/server/classes/c_comdef_users.class.php
+++ b/main_server/server/classes/c_comdef_users.class.php
@@ -147,9 +147,9 @@ class c_comdef_users implements i_comdef_has_parent
         \returns a reference to a c_comdef_user object. Null if none.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function &GetUserByLogin(   $in_login       ///< A string. The login ID.
-                            )
-    {
+    public function &GetUserByLogin(
+        $in_login       ///< A string. The login ID.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
         
@@ -205,9 +205,9 @@ class c_comdef_users implements i_comdef_has_parent
     /** \brief Add a user object to the end of the array.
     */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function AddUser(   &$in_user   ///< A reference to the user to be added.
-                        )
-    {
+    public function AddUser(
+        &$in_user   ///< A reference to the user to be added.
+    ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         if ($in_user instanceof c_comdef_user) {
             $in_user->SetParentObj($this);

--- a/main_server/server/config/comdef-config.inc.php
+++ b/main_server/server/config/comdef-config.inc.php
@@ -42,7 +42,7 @@
             if (!('.' == $file[0])
                 && is_dir(dirname(dirname(dirname(__FILE__))).'/local_server/server_admin/lang/'.$file)
                 && file_exists(dirname(dirname(dirname(__FILE__))).'/local_server/server_admin/lang/'.$file.'/name.txt')
-                && file_exists(dirname(dirname(dirname(__FILE__))).'/local_server/server_admin/lang/'.$comdef_global_language.'/format_codes.php') ) {
+                && file_exists(dirname(dirname(dirname(__FILE__))).'/local_server/server_admin/lang/'.$comdef_global_language.'/format_codes.php')) {
                 /// The "name.txt" file contains -ONLY- the language name, in its local language.
                 $name = file_get_contents(dirname(dirname(dirname(__FILE__))).'/local_server/server_admin/lang/'.$file.'/name.txt');
                 /// Each language has a text file, which has its name, in local language.

--- a/main_server/server/shared/classes/base_templates.inc.php
+++ b/main_server/server/shared/classes/base_templates.inc.php
@@ -130,8 +130,9 @@ interface i_comdef_auth
     /// \brief Test to see if a user is allowed to edit an instance (change the data).
     /// \returns true, if the user is allowed to edit, false, otherwise.
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function UserCanEdit( $in_user_object = null   ///< A reference to a c_comdef_user object, for the user to be validated. If null, or not supplied, the server current user is tested.
-                            );
+    public function UserCanEdit(
+        $in_user_object = null   ///< A reference to a c_comdef_user object, for the user to be validated. If null, or not supplied, the server current user is tested.
+    );
     // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 }
 

--- a/main_server/server/shared/classes/comdef_utilityclasses.inc.php
+++ b/main_server/server/shared/classes/comdef_utilityclasses.inc.php
@@ -285,9 +285,9 @@ function call_curl(
 /** \brief Returns the HTML for an "Admin Bar" along the top of the page.
     \returns the HTML for the bar.
 */
-function c_comdef_admin_bar( $in_http_vars ///< The aggregation of the $_GET and $_POST superglobals, as an associative array.
-                            )
-{
+function c_comdef_admin_bar(
+    $in_http_vars ///< The aggregation of the $_GET and $_POST superglobals, as an associative array.
+) {
     $x_file = $_SERVER ['SCRIPT_NAME'];
     require_once(dirname(__FILE__).'/../../../server/c_comdef_server.class.php');
     $ret = '';
@@ -303,7 +303,7 @@ function c_comdef_admin_bar( $in_http_vars ///< The aggregation of the $_GET and
             
             if (isset($in_http_vars['edit_cp'])
                 || (isset($in_http_vars['do_search']) && $in_http_vars['do_search'])
-                || (isset($in_http_vars['single_meeting_id']) && $in_http_vars['single_meeting_id']) ) {
+                || (isset($in_http_vars['single_meeting_id']) && $in_http_vars['single_meeting_id'])) {
                 $left_link = '<a href="'.$x_file.'?supports_ajax=yes&amp;lang_enum='.htmlspecialchars($lang_enum).'">';
                 $left_link .= c_comdef_htmlspecialchars($localized_strings['comdef_search_admin_strings']['Admin_Bar']['meeting_search']);
                 $left_link .= '</a>';
@@ -347,7 +347,7 @@ function c_comdef_admin_bar( $in_http_vars ///< The aggregation of the $_GET and
             $admin_links = '<div class="bmlt_admin_links_div">';
             if (isset($in_http_vars['edit_cp'])
                         || (isset($in_http_vars['do_search']) && $in_http_vars['do_search'])
-                        || (isset($in_http_vars['single_meeting_id']) && $in_http_vars['single_meeting_id']) ) {
+                        || (isset($in_http_vars['single_meeting_id']) && $in_http_vars['single_meeting_id'])) {
                 $admin_links .= '<div class="bmlt_admin_one_link_div">';
                     $admin_links .= '<a href="'.$x_file.'?supports_ajax=yes&amp;lang_enum='.htmlspecialchars($lang_enum).'">';
                         $admin_links .= c_comdef_htmlspecialchars($localized_strings['comdef_search_admin_strings']['Admin_Bar']['meeting_search']);
@@ -471,9 +471,9 @@ class bdfProfiler
     /**
     * \brief Marks a time
     */
-    public static function mark( $msg = null    ///< Optional string. A message to be displayed for this marker.
-                            )
-    {
+    public static function mark(
+        $msg = null    ///< Optional string. A message to be displayed for this marker.
+    ) {
         // If possible, we see how the memory is being used.
         if (function_exists('memory_get_usage')) {
             $mem = memory_get_usage();
@@ -520,9 +520,9 @@ class bdfProfiler
     *
     * \returns a string, with a series of tab-delimited lines; each containing the profile information for a marker.
     */
-    public static function output( $in_html = false    ///< If true, the output is html. Default is false.
-                                )
-    {
+    public static function output(
+        $in_html = false    ///< If true, the output is html. Default is false.
+    ) {
         if ($in_html) {
             $output = self::html_output();
         } else {


### PR DESCRIPTION
* The docker images are now PHP 7.4.
  * I made sure debugging still works.
* `phpspreadsheet` is upgraded, and now requires at least PHP 7.3
  * I verified the NAWS Import and World IDs Update still works.
* Made some benign changes to single line functions to make the linter happy.
* Made one benign change to ensure PHP 8.0 compatibility.