### PR TITLE
use relative path path for api base url

### DIFF
--- a/src/resources/views/frontend.blade.php
+++ b/src/resources/views/frontend.blade.php
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>BMLT Root Server</title>
     <script>
-        var baseUrl = '{{ url('/') }}';
+        var baseUrl = '{{ request()->getBaseUrl() }}';
     </script>
 
     @viteReactRefresh


### PR DESCRIPTION
This will use `/main_server` instead of `http://localhost:8000/main_server`. The full URL isn't really needed, so there's no reason to risk a possible bug in the full url calculation.