### PR TITLE
Fix for versionInt on GetServerInfo not being calculated properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.3 (TBD)
+* Fixed an issue with the versionInt not being calculated properly for GetServerInfo.
+
 ## 3.0.2 (January 23, 2023)
 * Fixed an issue that could cause the "History" tab in the Meeting Editor to hang on some meetings.
 

--- a/src/app/Http/Controllers/Query/SwitcherController.php
+++ b/src/app/Http/Controllers/Query/SwitcherController.php
@@ -500,7 +500,7 @@ class SwitcherController extends Controller
         $versionArray = explode('.', config('app.version'));
         return new JsonResponse([[
             'version' => config('app.version'),
-            'versionInt' => strval((intval($versionArray[0]) * 1000000) + (intval($versionArray[1]) * 1000) + intval(strstr($versionArray[2], '-', true))),
+            'versionInt' => strval((intval($versionArray[0]) * 1000000) + (intval($versionArray[1]) * 1000) + intval(strstr($versionArray[2], '-', true) ?: $versionArray[2])),
             'langs' => collect(scandir(base_path('lang')))->reject(fn ($dir) => $dir == '.' || $dir == '..')->sort()->join(','),
             'nativeLang' => config('app.locale'),
             'centerLongitude' => strval(legacy_config('search_spec_map_center_longitude')),

--- a/src/tests/Feature/GetServerInfoTest.php
+++ b/src/tests/Feature/GetServerInfoTest.php
@@ -38,12 +38,20 @@ class GetServerInfoTest extends TestCase
             ->assertJsonFragment(['version' => config('app.version')]);
     }
 
-    public function testVersionBeta()
+    public function testVersionIntBeta()
     {
-        Config::set('app.version', '3.0.0-beta');
+        Config::set('app.version', '3.0.2-beta');
         $this->get('/client_interface/json/?switcher=GetServerInfo')
             ->assertStatus(200)
-            ->assertJsonFragment(['versionInt' => '3000000']);
+            ->assertJsonFragment(['versionInt' => '3000002']);
+    }
+
+    public function testVersionIntNonBeta()
+    {
+        Config::set('app.version', '3.0.2');
+        $this->get('/client_interface/json/?switcher=GetServerInfo')
+            ->assertStatus(200)
+            ->assertJsonFragment(['versionInt' => '3000002']);
     }
 
     public function testNativeLang()


### PR DESCRIPTION
this worked fine if `-beta` etc existed but `strstr` returned false if `-` didn't exist. So `3.0.2` calculated to `3000000`. This fixes it to calculate to `3000002`, while still maintaining the support for hyphenated versions.