### PR TITLE
change the default sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.3 (TBD)
 * Fixed an issue with the `GetServerInfo` API that caused the `versionInt` to be calculated incorrectly for beta versions.
 * We'd forgotten to migrate the `GetSearchResults` API's `sort_key` parameter, so some old plugins were not working correctly. It has now been migrated.
+* Changed `GetSearchResults` API's default sort order to `weekday_tinyint, start_time, duration_time`.
 
 ## 3.0.2 (January 23, 2023)
 * Fixed an issue that could cause the "History" tab in the Meeting Editor to hang on some meetings.

--- a/src/app/Http/Controllers/Query/SwitcherController.php
+++ b/src/app/Http/Controllers/Query/SwitcherController.php
@@ -261,7 +261,7 @@ class SwitcherController extends Controller
                 }
             }
             if (is_null($sortKeys)) {
-                $sortKeys = ['lang_enum', 'weekday_tinyint', 'start_time', 'id_bigint'];
+                $sortKeys = ['weekday_tinyint', 'start_time', 'duration_time'];
             }
         }
 

--- a/src/tests/Feature/GetSearchResultsTest.php
+++ b/src/tests/Feature/GetSearchResultsTest.php
@@ -1365,8 +1365,8 @@ class GetSearchResultsTest extends TestCase
 
     public function testSortKeyInvalid()
     {
-        $meeting1 = $this->createMeeting(['lang_enum' => 'a', 'weekday_tinyint' => 3, 'start_time' => '01:00:00'], ['location_province' => 'a']);
-        $meeting2 = $this->createMeeting(['lang_enum' => 'b', 'weekday_tinyint' => 3, 'start_time' => '01:00:00'], ['location_province' => 'd']);
+        $meeting1 = $this->createMeeting(['lang_enum' => 'a', 'weekday_tinyint' => 3, 'start_time' => '01:00:00', 'duration_time' => '01:30:00'], ['location_province' => 'a']);
+        $meeting2 = $this->createMeeting(['lang_enum' => 'b', 'weekday_tinyint' => 3, 'start_time' => '01:00:00', 'duration_time' => '01:00:00'], ['location_province' => 'd']);
         $meeting3 = $this->createMeeting(['lang_enum' => 'c', 'weekday_tinyint' => 1, 'start_time' => '19:00:00'], ['location_province' => 'f']);
         $meeting4 = $this->createMeeting(['lang_enum' => 'd', 'weekday_tinyint' => 1, 'start_time' => '09:00:00'], ['location_province' => 'e']);
         $meeting5 = $this->createMeeting(['lang_enum' => 'e', 'weekday_tinyint' => 2, 'start_time' => '23:59:59'], ['location_province' => 'b']);
@@ -1378,12 +1378,12 @@ class GetSearchResultsTest extends TestCase
             ->assertJsonCount(6)
             ->json());
 
-        $this->assertEquals(strval($meeting1->id_bigint), $data[0]['id_bigint']);
-        $this->assertEquals(strval($meeting2->id_bigint), $data[1]['id_bigint']);
-        $this->assertEquals(strval($meeting3->id_bigint), $data[2]['id_bigint']);
-        $this->assertEquals(strval($meeting4->id_bigint), $data[3]['id_bigint']);
-        $this->assertEquals(strval($meeting5->id_bigint), $data[4]['id_bigint']);
-        $this->assertEquals(strval($meeting6->id_bigint), $data[5]['id_bigint']);
+        $this->assertEquals(strval($meeting4->id_bigint), $data[0]['id_bigint']);
+        $this->assertEquals(strval($meeting3->id_bigint), $data[1]['id_bigint']);
+        $this->assertEquals(strval($meeting6->id_bigint), $data[2]['id_bigint']);
+        $this->assertEquals(strval($meeting5->id_bigint), $data[3]['id_bigint']);
+        $this->assertEquals(strval($meeting2->id_bigint), $data[4]['id_bigint']);
+        $this->assertEquals(strval($meeting1->id_bigint), $data[5]['id_bigint']);
     }
 
     // sort_keys


### PR DESCRIPTION
For posterity: I considered adding meeting_name to the default sort, but decided against it. The meeting_name field is in the meetings_data table, and sorting by those fields requires us to sort in-memory in PHP. In modern PHP these types of sorts are very fast, but I still don't want a _default_ sort doing any sorting outside of the database. In truth, most plugins provide an explicit sort order, so this change probably won't impact anyone.