### PR TITLE
use v2 of aws action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,7 @@ jobs:
           make zip
 
       - name: Configure S3 AWS Credentials 🪪
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions/gh-ci-s3-artifact
           role-session-name: gh-actions
@@ -148,7 +148,7 @@ jobs:
 
       - name: Configure AWS Credentials 🪪
         if: contains(github.ref_name, 'main') || contains(github.ref_name, 'unstable')
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions/gh-ci-tf-bmlt-rs
           role-session-name: gh-actions-bmlt
@@ -207,7 +207,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS Credentials 🪪
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions/gh-ci-tf-bmlt-rs
           role-session-name: gh-actions-bmlt


### PR DESCRIPTION
they finally released a v2 with node 16 https://github.com/aws-actions/configure-aws-credentials/releases/tag/v2.0.0