### PR TITLE
rename Disabled User to Deactivated User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.5 (TBD)
+* Change name `Disabled User` to `Deactivated User`.
+
 ## 3.0.4 (March 20, 2023)
 * The `services` and `formats` filter parameters for the `GetSearchResults` API and the `formats` filter parameter for the `GetFormats` API now accept a comma separated string (e.g. `formats=1,-12,42`) in addition to the standard array syntax.
 * We'd forgotten to migrate the `$g_include_service_body_email_in_semantic` setting. When set to `true` in `auto-config.inc.php`, the `GetServiceBodies` API was supposed to return the `contact_email` field. This setting has now been migrated, and the functionality has been restored.

--- a/src/app/Http/Controllers/Legacy/LegacyAuthController.php
+++ b/src/app/Http/Controllers/Legacy/LegacyAuthController.php
@@ -42,7 +42,7 @@ class LegacyAuthController extends Controller
                 if ($apiType != $this->REQUEST_TYPE_WEB) {
                     $user = Auth::user();
                     if ($user) {
-                        if ($user->user_level_tinyint == User::USER_LEVEL_ADMIN || $user->user_level_tinyint == User::USER_LEVEL_DISABLED) {
+                        if ($user->user_level_tinyint == User::USER_LEVEL_ADMIN || $user->user_level_tinyint == User::USER_LEVEL_DEACTIVATED) {
                             Auth::logout();
                             $request->session()->invalidate();
                             $success = false;

--- a/src/app/Http/Resources/Admin/UserResource.php
+++ b/src/app/Http/Resources/Admin/UserResource.php
@@ -19,7 +19,7 @@ class UserResource extends JsonResource
         return [
             'id' => $this->id_bigint,
             'username' => $this->login_string,
-            'type' => User::USER_LEVEL_TO_USER_TYPE_MAP[$this->user_level_tinyint] ?? User::USER_TYPE_DISABLED,
+            'type' => User::USER_LEVEL_TO_USER_TYPE_MAP[$this->user_level_tinyint] ?? User::USER_TYPE_DEACTIVATED,
             'displayName' => $this->name_string,
             'description' => $this->description_string,
             'email' => $this->email_address_string,

--- a/src/app/Http/Resources/Query/MeetingResource.php
+++ b/src/app/Http/Resources/Query/MeetingResource.php
@@ -115,7 +115,7 @@ class MeetingResource extends JsonResource
 
         // Permissions
         $user = $request->user();
-        if (!is_null($user) && $user->user_level_tinyint != User::USER_LEVEL_DISABLED) {
+        if (!is_null($user) && $user->user_level_tinyint != User::USER_LEVEL_DEACTIVATED) {
             self::$userIsAuthenticated = true;
             if ($user->user_level_tinyint == User::USER_LEVEL_ADMIN) {
                 self::$userIsAdmin = true;

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -13,23 +13,23 @@ class User extends Model implements AuthenticatableContract
 
     public const USER_LEVEL_ADMIN = 1;
     public const USER_LEVEL_SERVICE_BODY_ADMIN = 2;
-    public const USER_LEVEL_DISABLED = 4;
+    public const USER_LEVEL_DEACTIVATED = 4;
     public const USER_LEVEL_OBSERVER = 5;
 
-    public const USER_TYPE_DISABLED = 'disabled';
+    public const USER_TYPE_DEACTIVATED = 'deactivated';
     public const USER_TYPE_ADMIN = 'admin';
     public const USER_TYPE_SERVICE_BODY_ADMIN = 'serviceBodyAdmin';
     public const USER_TYPE_OBSERVER = 'observer';
 
     public const USER_LEVEL_TO_USER_TYPE_MAP = [
-        self::USER_LEVEL_DISABLED => self::USER_TYPE_DISABLED,
+        self::USER_LEVEL_DEACTIVATED => self::USER_TYPE_DEACTIVATED,
         self::USER_LEVEL_ADMIN => self::USER_TYPE_ADMIN,
         self::USER_LEVEL_SERVICE_BODY_ADMIN => self::USER_TYPE_SERVICE_BODY_ADMIN,
         self::USER_LEVEL_OBSERVER => self::USER_TYPE_OBSERVER,
     ];
 
     public const USER_TYPE_TO_USER_LEVEL_MAP = [
-        self::USER_TYPE_DISABLED => self::USER_LEVEL_DISABLED,
+        self::USER_TYPE_DEACTIVATED => self::USER_LEVEL_DEACTIVATED,
         self::USER_TYPE_ADMIN => self::USER_LEVEL_ADMIN,
         self::USER_TYPE_SERVICE_BODY_ADMIN => self::USER_LEVEL_SERVICE_BODY_ADMIN,
         self::USER_TYPE_OBSERVER => self::USER_LEVEL_OBSERVER,
@@ -65,9 +65,9 @@ class User extends Model implements AuthenticatableContract
         return $this->user_level_tinyint == self::USER_LEVEL_SERVICE_BODY_ADMIN;
     }
 
-    public function isDisabled(): bool
+    public function isDeactivated(): bool
     {
-        return $this->user_level_tinyint == self::USER_LEVEL_DISABLED;
+        return $this->user_level_tinyint == self::USER_LEVEL_DEACTIVATED;
     }
 
     public function children()

--- a/src/app/Policies/DeniesDeactivatedUser.php
+++ b/src/app/Policies/DeniesDeactivatedUser.php
@@ -3,11 +3,11 @@ namespace App\Policies;
 
 use App\Models\User;
 
-trait DeniesDisabledUser
+trait DeniesDeactivatedUser
 {
     public function before(User $user, $ability)
     {
-        if ($user->isDisabled()) {
+        if ($user->isDeactivated()) {
             return false;
         }
     }

--- a/src/app/Policies/FormatPolicy.php
+++ b/src/app/Policies/FormatPolicy.php
@@ -8,7 +8,7 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 
 class FormatPolicy
 {
-    use DeniesDisabledUser, HandlesAuthorization;
+    use DeniesDeactivatedUser, HandlesAuthorization;
 
     public function viewAny(User $user)
     {

--- a/src/app/Policies/MeetingPolicy.php
+++ b/src/app/Policies/MeetingPolicy.php
@@ -9,7 +9,7 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 
 class MeetingPolicy
 {
-    use DeniesDisabledUser, HandlesAuthorization;
+    use DeniesDeactivatedUser, HandlesAuthorization;
 
     private ServiceBodyRepositoryInterface $serviceBodyRepository;
 

--- a/src/app/Policies/ServiceBodyPolicy.php
+++ b/src/app/Policies/ServiceBodyPolicy.php
@@ -9,7 +9,7 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 
 class ServiceBodyPolicy
 {
-    use DeniesDisabledUser, HandlesAuthorization;
+    use DeniesDeactivatedUser, HandlesAuthorization;
 
     private ServiceBodyRepositoryInterface $serviceBodyRepository;
 

--- a/src/app/Policies/UserPolicy.php
+++ b/src/app/Policies/UserPolicy.php
@@ -7,7 +7,7 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 
 class UserPolicy
 {
-    use DeniesDisabledUser, HandlesAuthorization;
+    use DeniesDeactivatedUser, HandlesAuthorization;
 
     public function viewAny(User $user)
     {

--- a/src/legacy/client_interface/html/index.php
+++ b/src/legacy/client_interface/html/index.php
@@ -5,7 +5,7 @@ require_once(__DIR__ . '/../../local_server/server_admin/c_comdef_admin_main_con
 $console_object = new c_comdef_admin_main_console($_REQUEST);
 $local_strings = $console_object->my_server->GetLocalStrings();
 $user_obj = $console_object->my_server->GetCurrentUserObj();
-if ($user_obj instanceof c_comdef_user && $user_obj->GetUserLevel() != _USER_LEVEL_DISABLED) {
+if ($user_obj instanceof c_comdef_user && $user_obj->GetUserLevel() != _USER_LEVEL_DEACTIVATED) {
     $service_body_ids = [];
     $service_body_set = [];
     $user_level = intval($user_obj->GetUserLevel());

--- a/src/legacy/local_server/index.php
+++ b/src/legacy/local_server/index.php
@@ -83,7 +83,7 @@ if (isset($http_vars ['bmlt_ajax_callback'])) {
 
         // We can only go past here is we are a logged-in user.
         $user_obj = $server->GetCurrentUserObj();
-        if (($user_obj instanceof c_comdef_user) && ($user_obj->GetUserLevel() != _USER_LEVEL_DISABLED)) {
+        if (($user_obj instanceof c_comdef_user) && ($user_obj->GetUserLevel() != _USER_LEVEL_DEACTIVATED)) {
             echo '<div class="admin_page_wrapper">';
             // OK. If they make it in here, it means they are legit, so display the logged-in console.
             require_once(dirname(__FILE__).'/server_admin/main_console.php');

--- a/src/legacy/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
+++ b/src/legacy/local_server/server_admin/c_comdef_admin_ajax_handler.class.php
@@ -51,7 +51,7 @@ class c_comdef_admin_ajax_handler
         $this->my_user = $this->my_server->GetCurrentUserObj();
 
         // We check this every chance that we get.
-        if (!$this->my_user || ($this->my_user->GetUserLevel() == _USER_LEVEL_DISABLED)) {
+        if (!$this->my_user || ($this->my_user->GetUserLevel() == _USER_LEVEL_DEACTIVATED)) {
             die('NOT AUTHORIZED');
         }
     }

--- a/src/legacy/local_server/server_admin/c_comdef_admin_main_console.class.php
+++ b/src/legacy/local_server/server_admin/c_comdef_admin_main_console.class.php
@@ -44,7 +44,7 @@ class c_comdef_admin_main_console
     public $my_all_service_bodies;         ///< This contains all Service bodies, cleaned for orphans.
     public $my_observable_service_bodies;  ///< This contains all observable service bodies.
     public $my_lang_ids;                   ///< Contains the enumerations for all the server langs.
-    
+
     /********************************************************************************************************//**
     \brief
     ************************************************************************************************************/
@@ -55,9 +55,9 @@ class c_comdef_admin_main_console
         $this->my_localized_strings = c_comdef_server::GetLocalStrings();
         $this->my_server = c_comdef_server::MakeServer();
         $this->my_user = $this->my_server->GetCurrentUserObj();
-        
+
         // We check this every chance that we get.
-        if (!$this->my_user || ($this->my_user->GetUserLevel() == _USER_LEVEL_DISABLED)) {
+        if (!$this->my_user || ($this->my_user->GetUserLevel() == _USER_LEVEL_DEACTIVATED)) {
             die('NOT AUTHORIZED');
         }
 
@@ -65,7 +65,7 @@ class c_comdef_admin_main_console
         usort($this->my_users, array("c_comdef_admin_main_console", "compare_names"));
         $url_path = GetURLToMainServerDirectory();
         $this->my_ajax_uri = $url_path.'?bmlt_ajax_callback=1';
-        
+
         $this->my_formats = array();
         $langs = $this->my_server->GetFormatLangs();
         $this->my_lang_ids = array_keys($langs);
@@ -83,9 +83,9 @@ class c_comdef_admin_main_console
                 }
             }
         }
-        
+
         // OK, we have a sorted array of unique format IDs. Now, we assign each one an array of format data per language.
-        
+
         foreach ($format_ids as $id) {
             $single_format = array();
             // Walk through the server languages...
@@ -108,48 +108,48 @@ class c_comdef_admin_main_console
                     }
                 }
             }
-            
+
             $this->my_formats[] = array ( 'id' => $id, 'formats' => $single_format );
         }
-        
+
         $service_bodies = $this->my_server->GetServiceBodyArray();
         usort($service_bodies, array("c_comdef_admin_main_console", "compare_names"));
         $this->my_service_bodies = array();
         $this->my_editable_service_bodies = array();
         $this->my_all_service_bodies = array();
         $this->my_observable_service_bodies = array();
-        
+
         for ($c = 0; $c < count($service_bodies); $c++) {
             $service_body = $service_bodies[$c];
             if ($service_body->UserCanEditMeetings()) {
                 array_push($this->my_service_bodies, $service_body);
             }
-            
+
             if ($service_body->UserCanEdit()) {
                 array_push($this->my_editable_service_bodies, $service_body);
             }
-            
+
             if ($service_body->UserCanObserve()) {
                 array_push($this->my_observable_service_bodies, $service_body);
             }
 
             array_push($this->my_all_service_bodies, $service_body);
         }
-        
+
         // We get all the available data fields, and create a local data member for their keys.
         $this->my_data_field_templates = c_comdef_meeting::GetDataTableTemplate();
         $longdata_obj = c_comdef_meeting::GetLongDataTableTemplate();
-        
+
         // We merge the two tables (data and longdata).
         if (is_array($this->my_data_field_templates) && count($this->my_data_field_templates) && is_array($longdata_obj) && count($longdata_obj)) {
             $this->my_data_field_templates = array_merge($this->my_data_field_templates, $longdata_obj);
         }
-        
+
         // Sort them by their field keys, so we have a consistent order.
         $flags = ( defined('SORT_NATURAL') && defined('SORT_FLAG_CASE') ) ? intval(SORT_NATURAL | SORT_FLAG_CASE) : null;
         ksort($this->my_data_field_templates, $flags);
     }
-    
+
     /********************************************************************************************************//**
     \brief Returns the HTML for the main admin console.
     \returns HTML code.
@@ -241,7 +241,7 @@ class c_comdef_admin_main_console
                 $ret .= ',';
             }
         }
-                
+
                 $ret .= '];'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= 'var g_user_levels = [';
                     $ret .= '[1,\''.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['user_editor_account_type_1']).'\'],';
@@ -269,7 +269,7 @@ class c_comdef_admin_main_console
                     } else {
                         $first = false;
                     }
-                    
+
                     $ret .= '{';
                         $ret .= '"id":'.$format['shared_id'];
                         $ret .= ',"key":"'.str_replace('"', '\"', str_replace("\n", ' ', $format['key'])).'"';
@@ -309,7 +309,7 @@ class c_comdef_admin_main_console
                 case 'location_postal_code_1':
                 case 'location_nation':
                     break;
-                
+
                 default:    // We display these ones.
                     if (!$first) {
                         $ret .= ',';
@@ -433,7 +433,7 @@ class c_comdef_admin_main_console
             $ret .= '{"key":"'.self::js_html(str_replace("\n", ' ', $key)).'","value":"'.self::js_html(str_replace("\n", ' ', $value)).'"}';
         }
                 $ret .= (defined('__DEBUG_MODE__') ? "\n" : '').'];';
-                
+
             /****
              * End format_type_enum
              */
@@ -443,7 +443,7 @@ class c_comdef_admin_main_console
             $ret .= '<script type="text/javascript" src="'.(((dirname($_SERVER['PHP_SELF']) != '/') && (dirname($_SERVER['PHP_SELF']) != '\\')) ? dirname($_SERVER['PHP_SELF']) : '').'/local_server/server_admin/jquery.slim.min.js"></script>';
             $ret .= '<noscript class="main_noscript">'.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['noscript']).'</noscript>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             // Belt and suspenders. Just make sure the user is legit.
-        if (($this->my_user instanceof c_comdef_user) && ($this->my_user->GetUserLevel() != _USER_LEVEL_DISABLED)) {
+        if (($this->my_user instanceof c_comdef_user) && ($this->my_user->GetUserLevel() != _USER_LEVEL_DEACTIVATED)) {
             // Figure out which output will be sent, according to the user level.
             switch ($this->my_user->GetUserLevel()) {
                 case _USER_LEVEL_SERVER_ADMIN:
@@ -463,21 +463,21 @@ class c_comdef_admin_main_console
                     $ret .= '<div class="bmlt_admin_observer_link_div"><a target="_blank" href="client_interface/html/" class="bmlt_admin_observer_link_a">'.self::js_html($this->my_localized_strings['comdef_server_admin_strings']['Observer_Link_Text']).'</a></div>';
                     $ret .= $this->return_user_account_settings_panel();
                     break;
-                
+
                 default:
                     die('USER NOT AUTHORIZED');
                 break;
             }
         }
-        
+
         $ret .= '</div>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         if (isset($_GET['edit_meeting']) && intval($_GET['edit_meeting'])) {
             $ret .= '<script type="text/javascript">admin_handler_object.openMeetingForEditing('.intval($_GET['edit_meeting']).');</script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         }
-        
+
         return  $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief Does an HTML sub, and also "slashes" apostrophes.
     \returns "Cleaned" text
@@ -499,7 +499,7 @@ class c_comdef_admin_main_console
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = 'NOT AUTHORIZED TO EDIT USERS';
-        
+
         if ($this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN) {
             $ret = '<div id="bmlt_admin_format_editor_disclosure_div" class="bmlt_admin_format_editor_disclosure_div bmlt_admin_format_editor_disclosure_div_closed">'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= '<a class="bmlt_admin_format_editor_disclosure_a" href="javascript:admin_handler_object.toggleFormatEditor();">';
@@ -533,10 +533,10 @@ class c_comdef_admin_main_console
             $ret .= '</div>'.(defined('__DEBUG_MODE__') ? "\n" : '');
             $ret .= '<script type="text/javascript">admin_handler_object.populateFormatEditor()</script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs the User editor panel. Only Server Admins get this one.
     \returns The HTML and JavaScript for the "Edit Users" section.
@@ -596,7 +596,7 @@ class c_comdef_admin_main_console
                             $ret .= '</div>'.(defined('__DEBUG_MODE__') ? "\n" : '');
                         $ret .= '</div>'.(defined('__DEBUG_MODE__') ? "\n" : '');
                     $ret .= '</div>'.(defined('__DEBUG_MODE__') ? "\n" : '');
-                    
+
                     $ret .= $this->return_single_user_editor_panel($users);
                 $ret .= '</div>'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= '<script type="text/javascript">admin_handler_object.populateUserEditor()</script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
@@ -604,10 +604,10 @@ class c_comdef_admin_main_console
                 $ret = '';
             }
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs a window for the User administrator.
     \returns The HTML and JavaScript for the "User Administration" section.
@@ -674,10 +674,10 @@ class c_comdef_admin_main_console
             $ret .= '</fieldset>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         $ret .= '</div>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         $ret .= '<script type="text/javascript">admin_handler_object.populateUserEditor()</script>'.(defined('__DEBUG_MODE__') ? "\n" : '');
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This creates the HTML for a user selection popup menu.
     \returns The HTML and JavaScript for the popup menu (select element).
@@ -703,10 +703,10 @@ class c_comdef_admin_main_console
             $ret .= '<option value="0" selected="selected">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['user_editor_create_new_user_option']).'</option>';
         }
         $ret .= '</select>'.(defined('__DEBUG_MODE__') ? "\n" : '');
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This creates the HTML for a user level popup menu.
     \returns The HTML and JavaScript for the popup menu (select element).
@@ -723,7 +723,7 @@ class c_comdef_admin_main_console
             $ret .= '<option value="" disabled="disabled"></option>';
             $ret .= '<option value="4">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['user_editor_account_type_4']).'</option>';
         $ret .= '</select>';
-        
+
         return $ret;
     }
 
@@ -777,7 +777,7 @@ class c_comdef_admin_main_console
             $ret .= '</span>';
             $ret .= '<div class="clear_both"></div>';
         $ret .= '</div>';
-        
+
         return $ret;
     }
 
@@ -824,15 +824,15 @@ class c_comdef_admin_main_console
                         $ret .= '</div>'.(defined('__DEBUG_MODE__') ? "\n" : '');
                     $ret .= '</div>';
                 $ret .= '</div>';
-            
+
                 $ret .= $this->return_single_service_body_editor_panel();
             $ret .= '</div>';
             $ret .= '<script type="text/javascript">admin_handler_object.populateServiceBodyEditor()</script>';
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs a window for the Service Body administrator.
     \returns The HTML and JavaScript for the "Service Body Administration" section.
@@ -850,7 +850,7 @@ class c_comdef_admin_main_console
         } else {
             $ret .= $this->create_service_body_popup();
         }
-                
+
                 $ret .= '</legend>'.(defined('__DEBUG_MODE__') ? "\n" : '');
                 $ret .= '<div class="naws_link_div" id="service_body_editor_naws_link_div">';
                     $ret .= '<a id="service_body_editor_naws_link_a" href="">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['service_body_editor_uri_naws_format_text']).'</a>';
@@ -887,7 +887,7 @@ class c_comdef_admin_main_console
                 $ret .= '</span>';
                 $ret .= '<div class="clear_both"></div>';
             $ret .= '</div>';
-            
+
             // This is the part of the form that allows us to import a list of IDs from NAWS, and replace them in our database.
             if (defined('__NAWS_IMPORT__')) {
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
@@ -924,33 +924,33 @@ class c_comdef_admin_main_console
                     $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_service_body_editor_helpline_text_input" type="text" value="" onkeyup="admin_handler_object.handleTextInputServiceBodyChange(this, 8);" onchange="admin_handler_object.handleTextInputServiceBodyChange(this, 8);" onpaste="setTimeout(function() { admin_handler_object.handleTextInputServiceBodyChange(this, 8); }, 0);" oncut="setTimeout(function() { admin_handler_object.handleTextInputServiceBodyChange(this, 8); }, 0);" onfocus="admin_handler_object.handleTextInputFocus(this);" onblur="admin_handler_object.handleTextInputBlur(this);" /></span>';
                     $ret .= '<div class="clear_both"></div>';
                 $ret .= '</div>';
-                
+
                 $full_editors = $this->get_full_editor_users();
                 $basic_editors = $this->get_basic_editor_users();
                 $observers = $this->get_observer_users();
-                
+
         if (count($full_editors)) {
             $ret .= '<div id="service_body_admin_full_editor_list_div" class="bmlt_admin_one_line_in_a_form clear_both">';
                 $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['service_body_editor_screen_sb_admin_full_editor_label']).'</span>';
                 $ret .= '<span class="bmlt_admin_value_left light_italic_display">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['service_body_editor_screen_sb_admin_full_editor_desc']).'</span>';
                 $ret .= '<div class="clear_both"></div>';
-                
+
             foreach ($full_editors as $user) {
                     $ret .= '<span class="bmlt_admin_med_label_right"><input type="checkbox" id="service_body_admin_editor_user_'.$user->GetID().'_checkbox" onchange="admin_handler_object.serviceBodyUserChecboxHandler('.$user->GetID().',this);" onclick="admin_handler_object.serviceBodyUserChecboxHandler('.$user->GetID().',this);" /></span>';
                     $ret .= '<label class="bmlt_admin_med_label_left" for="service_body_admin_editor_user_'.$user->GetID().'_checkbox">'.htmlspecialchars($user->GetLocalName()).'</label>';
                     $ret .= '<div class="clear_both"></div>';
             }
-                    
+
                     $ret .= '</div>';
                     $ret .= '<div class="clear_both"></div>';
         }
-        
+
         if (count($observers)) {
             $ret .= '<div id="service_body_admin_observer_list_div" class="bmlt_admin_one_line_in_a_form clear_both">';
                 $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['service_body_editor_screen_sb_admin_observer_label']).'</span>';
                 $ret .= '<span class="bmlt_admin_value_left light_italic_display">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['service_body_editor_screen_sb_admin_observer_desc']).'</span>';
                 $ret .= '<div class="clear_both"></div>';
-                
+
             foreach ($observers as $user) {
                     $ret .= '<span class="bmlt_admin_med_label_right"><input type="checkbox" id="service_body_admin_editor_user_'.$user->GetID().'_checkbox" onchange="admin_handler_object.serviceBodyUserChecboxHandler('.$user->GetID().',this);" onclick="admin_handler_object.serviceBodyUserChecboxHandler('.$user->GetID().',this);" /></span>';
                     $ret .= '<label class="bmlt_admin_med_label_left" for="service_body_admin_editor_user_'.$user->GetID().'_checkbox">'.htmlspecialchars($user->GetLocalName()).'</label>';
@@ -959,15 +959,15 @@ class c_comdef_admin_main_console
                     $ret .= '</div>';
                     $ret .= '<div class="clear_both"></div>';
         }
-                
+
                 $ret .= '<div class="clear_both"></div>';
                 $ret .= $this->return_service_body_editor_button_panel();
             $ret .= '</fieldset>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         $ret .= '</div>'.(defined('__DEBUG_MODE__') ? "\n" : '');
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This gets just the Service Body Admin Users, and returns their objects in an array.
     \returns An array with the user objects (instances of c_comdef_user)
@@ -977,17 +977,17 @@ class c_comdef_admin_main_console
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = array ();
-        
+
         for ($c = 0; $c < count($this->my_users); $c++) {
             $user = $this->my_users[$c];
             if ($user->GetUserLevel() == _USER_LEVEL_SERVICE_BODY_ADMIN) {
                 array_push($ret, $user);
             }
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This gets just the Service Body Editor (Trainee) Users, and returns their objects in an array.
     \returns An array with the user objects (instances of c_comdef_user)
@@ -997,17 +997,17 @@ class c_comdef_admin_main_console
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = array ();
-        
+
         for ($c = 0; $c < count($this->my_users); $c++) {
             $user = $this->my_users[$c];
             if ($user->GetUserLevel() == _USER_LEVEL_EDITOR) {
                 array_push($ret, $user);
             }
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This gets just the Observer Users, and returns their objects in an array.
     \returns An array with the user objects (instances of c_comdef_user)
@@ -1017,17 +1017,17 @@ class c_comdef_admin_main_console
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = array ();
-        
+
         for ($c = 0; $c < count($this->my_users); $c++) {
             $user = $this->my_users[$c];
             if ($user->GetUserLevel() == _USER_LEVEL_OBSERVER) {
                 array_push($ret, $user);
             }
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This creates the HTML for a Service body parent selection popup menu.
     \returns The HTML and JavaScript for the popup menu (select element).
@@ -1039,16 +1039,16 @@ class c_comdef_admin_main_console
         $ret = '<select id="bmlt_admin_single_service_body_editor_parent_select" class="bmlt_admin_single_service_body_editor_parent_select" onchange="admin_handler_object.recalculateServiceBody();">'.(defined('__DEBUG_MODE__') ? "\n" : '');
 
             $ret .= '<option id="parent_popup_option_0" selected="selected" value="0">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['service_body_parent_popup_no_parent_option']).'</option>'.(defined('__DEBUG_MODE__') ? "\n" : '');
-            
+
         for ($index = 0; $index  < count($this->my_editable_service_bodies); $index++) {
             $service_body = $this->my_editable_service_bodies[$index];
             $ret .= '<option id="parent_popup_option_'.$service_body->GetID().'" value="'.$service_body->GetID().'">'.htmlspecialchars($service_body->GetLocalName()).'</option>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         }
         $ret .= '</select>'.(defined('__DEBUG_MODE__') ? "\n" : '');
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This creates the HTML for a Service body selection popup menu.
     \returns The HTML and JavaScript for the popup menu (select element).
@@ -1069,26 +1069,26 @@ class c_comdef_admin_main_console
             }
             $ret .= '>'.htmlspecialchars($service_body->GetLocalName()).'</option>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         }
-            
+
             // Service body admin adds a special one at the end for creating a new one.
         if ($this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN) {
             if (!$first) {
                 $ret .= '<option value="" disabled="disabled"></option>';
             }
-            
+
             $ret .= '<option value="0"';
-            
+
             if ($first) {
                 $ret .= ' selected="selected"';
             }
-            
+
             $ret .= '>'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['service_body_editor_create_new_sb_option']).'</option>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         }
         $ret .= '</select>'.(defined('__DEBUG_MODE__') ? "\n" : '');
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This creates the HTML for a Service body selection popup menu.
     \returns The HTML and JavaScript for the popup menu (select element).
@@ -1126,10 +1126,10 @@ class c_comdef_admin_main_console
                 $ret .= htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['service_body_editor_type_c_comdef_service_body__WSC__']);
             $ret .= '</option>';
         $ret .= '</select>';
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This returns the user name for a given user ID.
     \returns a string, containing the name.
@@ -1140,7 +1140,7 @@ class c_comdef_admin_main_console
     ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
-        
+
         for ($index = 0; $index  < count($this->my_users); $index++) {
             $user = $this->my_users[$index];
             if ($user->GetID() == $in_user_id) {
@@ -1148,10 +1148,10 @@ class c_comdef_admin_main_console
                 break;
             }
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This creates the HTML for a Service body selection popup menu.
     \returns The HTML and JavaScript for the popup menu (select element).
@@ -1169,10 +1169,10 @@ class c_comdef_admin_main_console
             }
         }
         $ret .= '</select>';
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs the Service body editor buttons as a div.
     \returns The HTML and JavaScript for the button panel.
@@ -1199,10 +1199,10 @@ class c_comdef_admin_main_console
             $ret .= '<span class="bmlt_admin_meeting_editor_form_meeting_button_right_span"><a id="bmlt_admin_service_body_editor_form_meeting_template_cancel_button" href="javascript:admin_handler_object.cancelServiceBodyEdit();" class="bmlt_admin_ajax_button button_disabled">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['service_body_cancel_button']).'</a></span>';
             $ret .= '<div class="clear_both"></div>';
         $ret .= '</div>';
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs the meeting editor section of the console. Most user levels (not observers) have it.
     \returns The HTML and JavaScript for the "Edit Meetings" section.
@@ -1212,15 +1212,15 @@ class c_comdef_admin_main_console
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = '';
-        
+
         $can_edit = false;
-        
+
         for ($c = 0; $c < count($this->my_service_bodies); $c++) {
             if ($this->my_service_bodies[$c]->UserCanEditMeetings()) {
                 $can_edit = true;
             }
         }
-        
+
         if ($can_edit) {
             $ret = '<div id="bmlt_admin_meeting_editor_disclosure_div" class="bmlt_admin_meeting_editor_disclosure_div bmlt_admin_meeting_editor_disclosure_div_closed">';
                 $ret .= '<a class="bmlt_admin_meeting_editor_disclosure_a" href="javascript:admin_handler_object.toggleMeetingEditor();">';
@@ -1263,7 +1263,7 @@ class c_comdef_admin_main_console
                 $ret .= '<div class="clear_both"></div>';
             $ret .= '</div>';
         }
-        
+
         return $ret;
     }
 
@@ -1288,7 +1288,7 @@ class c_comdef_admin_main_console
         $ret .= '<div class="clear_both"></div>';
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs the meeting search specification panel of the meeting editor.
     \returns The HTML and JavaScript for the Edit Meetings Search Specifier section.
@@ -1349,7 +1349,7 @@ class c_comdef_admin_main_console
             $ret .= '</div>';
             $ret .= '<div class="clear_both"></div>';
         $ret .= '</div>';
-        
+
         return $ret;
     }
 
@@ -1386,7 +1386,7 @@ class c_comdef_admin_main_console
 
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs a panel that displays a choice of Service bodies for the user to choose.
     \returns The HTML and JavaScript for the Edit Meetings Search Specifier section.
@@ -1396,7 +1396,7 @@ class c_comdef_admin_main_console
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = 'NOT AUTHORIZED';
-        
+
         if (count($this->my_service_bodies)) {
             $ret = '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                 $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_search_service_bodies_label']).'</span>';
@@ -1409,7 +1409,7 @@ class c_comdef_admin_main_console
                 $ret .= '<div class="clear_both"></div>';
             $ret .= '</div>';
         }
-        
+
         return $ret;
     }
 
@@ -1436,26 +1436,26 @@ class c_comdef_admin_main_console
                 $child_content .= $this->populate_service_bodies($service_body->GetID());
             }
         }
-        
+
         // At this point, we have the main Service body, as well as any child content.
-        
+
         if ($service_body_content) {
             $service_body_content = '<dt class="service_body_dt'.($child_content != '' ? ' service_body_parent_dt' : '').'">'.$service_body_content.'</dt>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         }
-        
+
         if ($child_content) {
             $child_content = '<dd class="bmlt_admin_service_body'.($service_body_content != '' ? '_child' : '').'_dd">'.$child_content.'</dd>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         }
-        
+
         $ret = '';
-        
+
         if ($service_body_content || $child_content) {
             $ret = '<dl class="service_body_dl">'.(defined('__DEBUG_MODE__') ? "\n" : '').$service_body_content.(defined('__DEBUG_MODE__') ? "\n" : '').$child_content.'</dl>'.(defined('__DEBUG_MODE__') ? "\n" : '');
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs the combined new meetings/search results panel.
     \returns The HTML and JavaScript for the Edit Meetings Search Results section.
@@ -1478,7 +1478,7 @@ class c_comdef_admin_main_console
 
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs a panel for creating new meetings that goes above the results.
     \returns The HTML and JavaScript for the New Meetings section.
@@ -1500,7 +1500,7 @@ class c_comdef_admin_main_console
 
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs the meeting search results panel of the meeting editor.
     \returns The HTML and JavaScript for the Search Results section.
@@ -1517,7 +1517,7 @@ class c_comdef_admin_main_console
 
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs a template to be filled in for a single meeting that will be edited.
     \returns The HTML and JavaScript for the "Edit Meetings" section.
@@ -1557,10 +1557,10 @@ class c_comdef_admin_main_console
                 $ret .= $this->return_meeting_editor_button_panel();
             $ret .= '</div>';
         $ret .= '</div>';
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs the meeting editor buttons as a div.
     \returns The HTML and JavaScript for the button panel.
@@ -1585,10 +1585,10 @@ class c_comdef_admin_main_console
             $ret .= '<span class="bmlt_admin_meeting_editor_form_meeting_button_right_span"><a id="bmlt_admin_meeting_editor_form_meeting_template_cancel_button" href="javascript:admin_handler_object.cancelMeetingEdit(template);" class="bmlt_admin_ajax_button button">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_cancel_button']).'</a></span>';
             $ret .= '<div class="clear_both"></div>';
         $ret .= '</div>';
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs a template to be filled in for the basic options tab.
     \returns The HTML and JavaScript for the option sheet.
@@ -1599,7 +1599,7 @@ class c_comdef_admin_main_console
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         if (($this->my_user->GetUserLevel() == _USER_LEVEL_EDITOR) || ($this->my_user->GetUserLevel() == _USER_LEVEL_SERVICE_BODY_ADMIN) || ($this->my_user->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN)) {
             $ret = '<div id="bmlt_admin_meeting_template_basic_sheet_div" class="bmlt_admin_meeting_option_sheet_div">';
-        
+
             if ($this->my_user->GetUserLevel() != _USER_LEVEL_EDITOR) {
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right"><input type="checkbox" id="bmlt_admin_meeting_template_published_checkbox" /></span>';
@@ -1730,10 +1730,10 @@ class c_comdef_admin_main_console
                 $ret .= '</div>';
             $ret .= '</div>';
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This constructs a template to be filled in for the location options tab.
     \returns The HTML and JavaScript for the option sheet.
@@ -1751,7 +1751,7 @@ class c_comdef_admin_main_console
                 $ret .= '<div class="bmlt_admin_single_meeting_editor_map_bottom_bar_div">';
                 $ret .= '</div>';
             $ret .= '</div>';
-            
+
             $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                 $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_venue_type']).'</span>';
                 $ret .= '<span class="bmlt_admin_value_left">';
@@ -1763,7 +1763,7 @@ class c_comdef_admin_main_console
                 $ret .= '</span>';
                 $ret .= '<div class="clear_both"></div>';
             $ret .= '</div>';
-            
+
             $ret .= '<div class="clear_both"></div>';
             $ret .= '<div id="bmlt_admin_single_location_template_long_lat_div" class="bmlt_admin_single_location_long_lat_div">';
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
@@ -1862,7 +1862,7 @@ class c_comdef_admin_main_console
                     $ret .= '<span class="bmlt_admin_value_left"><input id="bmlt_admin_single_meeting_editor_template_meeting_nation_text_input" type="text" maxlength="255" /><div class="helper_text">' . htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_nation_prompt']).'</div></span>';
                     $ret .= '<div class="clear_both"></div>';
                 $ret .= '</div>';
-                
+
                 $ret .= '<div class="bmlt_admin_meeting_inner_div">';
                     $ret .= '<span id="bmlt_admin_single_meeting_editor_template_meeting_virtual_meta"></span>';
                     $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
@@ -1886,7 +1886,7 @@ class c_comdef_admin_main_console
 
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief
     \returns The HTML and JavaScript for the option sheet.
@@ -1919,7 +1919,7 @@ class c_comdef_admin_main_console
 
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief
     \returns The HTML and JavaScript for the option sheet.
@@ -1960,7 +1960,7 @@ class c_comdef_admin_main_console
                 case 'virtual_meeting_link':
                 case 'virtual_meeting_additional_info':
                     break;
-            
+
                 default:    // We display these ones.
                     if (array_key_exists('meeting_editor_screen_meeting_' . $key . '_label', $this->my_localized_strings['comdef_server_admin_strings'])) {
                         $prompt = $this->my_localized_strings['comdef_server_admin_strings']['meeting_editor_screen_meeting_' . $key . '_label'];
@@ -1982,7 +1982,7 @@ class c_comdef_admin_main_console
 
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief
     \returns The HTML and JavaScript for the option sheet.
@@ -2156,7 +2156,7 @@ class c_comdef_admin_main_console
                             $ret .= '"';
             }
                             $ret .= '>'.htmlspecialchars($this->my_service_bodies[$c]->GetLocalName());
-                            
+
             if ($c < (count($this->my_service_bodies) - 1)) {
                 $ret .= ',';
             }
@@ -2165,7 +2165,7 @@ class c_comdef_admin_main_console
                     $ret .= '</div>';
                     $ret .= '<div class="clear_both"></div>';
                 $ret .= '</div>';
-                
+
                 $ret .= '<div class="bmlt_admin_one_line_in_a_form clear_both">';
                     $ret .= '<span class="bmlt_admin_med_label_right">'.htmlspecialchars($this->my_localized_strings['comdef_server_admin_strings']['account_email_label']).'</span>';
                     $ret .= '<span class="bmlt_admin_value_left"><input name="bmlt_admin_user_email_input" id="bmlt_admin_user_email_input" type="text" value="'.htmlspecialchars($this->my_user->GetEmailAddress()).'" onkeyup="admin_handler_object.handleTextInputChange(this);" onchange="admin_handler_object.handleTextInputChange(this);" onfocus="admin_handler_object.handleTextInputFocus(this);" onblur="admin_handler_object.handleTextInputBlur(this);" /></span>';
@@ -2192,7 +2192,7 @@ class c_comdef_admin_main_console
                 $ret .= '</div>';
             $ret .= '</div>';
         $ret .= '</div>';
-        
+
         return  $ret;
     }
 

--- a/src/legacy/local_server/server_admin/c_comdef_admin_xml_handler.class.php
+++ b/src/legacy/local_server/server_admin/c_comdef_admin_xml_handler.class.php
@@ -33,7 +33,7 @@ class c_comdef_admin_xml_handler
     public $server;                        ///< The BMLT server model instance.
     public $my_localized_strings;          ///< An array of localized strings.
     public $handled_service_body_ids;      ///< This is used to ensure that we respect the hierarchy when doing a hierarchical Service body request.
-    
+
     /********************************************************************************************************//**
     \brief The class constructor.
     ************************************************************************************************************/
@@ -46,7 +46,7 @@ class c_comdef_admin_xml_handler
         $this->my_localized_strings = c_comdef_server::GetLocalStrings();
         $this->handled_service_body_ids = array();
     }
-    
+
     /********************************************************************************************************//**
     \brief This returns the URL to the main server. It needs extra stripping, because we're depper than usual.
 
@@ -58,7 +58,7 @@ class c_comdef_admin_xml_handler
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         return dirname(dirname(GetURLToMainServerDirectory(false))).'/';
     }
-    
+
     /********************************************************************************************************//**
     \brief This extracts a meeting's essential data as XML.
 
@@ -69,9 +69,9 @@ class c_comdef_admin_xml_handler
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = '';
-        
+
         $meeting_object = c_comdef_server::GetOneMeeting($meeting_id);
-        
+
         if (($meeting_object instanceof c_comdef_meeting) && (intval($meeting_object->GetID()) == intval($meeting_id))) {
             $localized_strings = c_comdef_server::GetLocalStrings();
             $meeting_id = $meeting_object->GetID();
@@ -82,9 +82,9 @@ class c_comdef_admin_xml_handler
             $meeting_borough = str_replace('"', "'", str_replace("\n", " ", str_replace("\r", " ", $meeting_object->GetMeetingDataValue('location_city_subsection'))));
             $meeting_town = str_replace('"', "'", str_replace("\n", " ", str_replace("\r", " ", $meeting_object->GetMeetingDataValue('location_municipality'))));
             $meeting_state = str_replace('"', "'", str_replace("\n", " ", str_replace("\r", " ", $meeting_object->GetMeetingDataValue('location_province'))));
-            
+
             $ret = '"meeting_id","meeting_name","weekday_tinyint","weekday_name","start_time","location_city_subsection","location_municipality","location_province"'."\n";
-            
+
             if ($meeting_id) {
                 $change_line['meeting_id'] = $meeting_id;
             } else {
@@ -132,17 +132,17 @@ class c_comdef_admin_xml_handler
             } else {
                 $change_line['location_province'] = '';
             }
-            
+
             $ret .= '"'.implode('","', $change_line).'"'."\n";
             $ret = $this->TranslateCSVToXML($ret);
             $ret = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<meeting xmlns=\"http://".c_comdef_htmlspecialchars($_SERVER['SERVER_NAME'])."\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"".$this->getMainURL()."client_interface/xsd/RestoreDeletedMeeting.php\">$ret</meeting>";
         } else {
             $ret = '<h1>PROGRAM ERROR (MEETING FETCH FAILED)</h1>';
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This is called to process the input and generate the output. It is the "heart" of the class.
 
@@ -162,37 +162,37 @@ class c_comdef_admin_xml_handler
                     case 'get_permissions':
                         $ret = $this->process_capabilities_request();
                         break;
-                    
+
                     case 'get_service_body_info':
                         $ret = $this->process_service_bodies_info_request();
                         break;
-                    
+
                     case 'get_format_info':
                         $ret = $this->process_format_info();
                         break;
-                    
+
                     case 'get_field_templates':
                         $ret = $this->process_get_field_templates();
                         break;
-                    
+
                     case 'get_meetings':
                         $ret = $this->process_meeting_search();
                         break;
-                    
+
                     case 'get_deleted_meetings':
                         $ret = $this->process_deleted_meetings();
                         break;
-                    
+
                     case 'get_changes':
                         $ret = $this->process_changes();
                         break;
-                    
+
                     case 'add_meeting':
                         $this->http_vars['meeting_id'] = 0;
                         unset($this->http_vars['meeting_id']);    // Make sure that we have no meeting ID. This forces an add.
                         $ret = $this->process_meeting_modify();
                         break;
-                    
+
                     case 'rollback_meeting_to_before_change':
                         if (intval($this->http_vars['meeting_id']) &&  intval($this->http_vars['change_id'])) {    // Make sure that we are referring to a meeting and a change.
                             $ret = $this->process_rollback_meeting();
@@ -200,7 +200,7 @@ class c_comdef_admin_xml_handler
                             $ret = '<h1>BAD ADMIN ACTION</h1>';
                         }
                         break;
-                    
+
                     case 'restore_deleted_meeting':
                         if (intval($this->http_vars['meeting_id'])) {    // Make sure that we are referring to a meeting
                             $ret = $this->process_restore_deleted_meeting();
@@ -208,7 +208,7 @@ class c_comdef_admin_xml_handler
                             $ret = '<h1>BAD ADMIN ACTION</h1>';
                         }
                         break;
-                    
+
                     case 'modify_meeting':
                         if (intval($this->http_vars['meeting_id'])) {    // Make sure that we are referring to a meeting.
                             $ret = $this->process_meeting_modify();
@@ -216,7 +216,7 @@ class c_comdef_admin_xml_handler
                             $ret = '<h1>BAD ADMIN ACTION</h1>';
                         }
                         break;
-                    
+
                     case 'delete_meeting':
                         if (intval($this->http_vars['meeting_id'])) {    // Make sure that we are referring to a meeting
                             $ret = $this->process_meeting_delete();
@@ -233,7 +233,7 @@ class c_comdef_admin_xml_handler
                         $ret = '<h1>BAD ADMIN ACTION</h1>';
                         break;
                 }
-                
+
                 set_time_limit(30); // Probably unnecessary...
             } else {
                 $ret = '<h1>BAD ADMIN ACTION</h1>';
@@ -241,10 +241,10 @@ class c_comdef_admin_xml_handler
         } else {
             $ret = '<h1>NOT AUTHORIZED</h1>';
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This is a basic funtion that tests the current user, to see if they are basically valid.
 
@@ -255,16 +255,16 @@ class c_comdef_admin_xml_handler
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = false;
-        
+
         $user_obj = $this->server->GetCurrentUserObj();
         // First, make sure the use is of the correct general type.
-        if (isset($user_obj) && ($user_obj instanceof c_comdef_user) && ($user_obj->GetUserLevel() != _USER_LEVEL_DISABLED) && ($user_obj->GetUserLevel() != _USER_LEVEL_SERVER_ADMIN) && ($user_obj->GetID() > 1)) {
+        if (isset($user_obj) && ($user_obj instanceof c_comdef_user) && ($user_obj->GetUserLevel() != _USER_LEVEL_DEACTIVATED) && ($user_obj->GetUserLevel() != _USER_LEVEL_SERVER_ADMIN) && ($user_obj->GetID() > 1)) {
             $ret = true;
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to get change records.
 
@@ -275,7 +275,7 @@ class c_comdef_admin_xml_handler
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = '<h1>NOT AUTHORIZED</h1>';
-        
+
         // First, make sure the use is of the correct general type.
         if ($this->basic_user_validation()) {
             $start_date = (isset($this->http_vars['from_date']) && $this->http_vars['from_date']) ? strtotime($this->http_vars['from_date']) : (isset($this->http_vars['start_date']) && intval($this->http_vars['start_date']) ? intval($this->http_vars['start_date']) : null);
@@ -283,16 +283,16 @@ class c_comdef_admin_xml_handler
             $meeting_id = isset($this->http_vars['meeting_id']) && intval($this->http_vars['meeting_id']) ? intval($this->http_vars['meeting_id']) : null;
             $user_id = isset($this->http_vars['user_id']) && intval($this->http_vars['user_id']) ? intval($this->http_vars['user_id']) : null;
             $service_body_id = null;
-            
+
             if (isset($this->http_vars['service_body_id'])) {
                 $service_body_array = explode(",", $this->http_vars['service_body_id']);
-                
+
                 foreach ($service_body_array as $sb) {
                     $sb_int = intval($sb);
-                    
+
                     if ($sb_int > 0) {
                         $sb_obj = c_comdef_server::GetServiceBodyByIDObj($sb_int);
-                        
+
                         if ($sb_obj instanceof c_comdef_service_body) {
                             if ($sb_obj->UserCanObserve()) {
                                 if (!isset($service_body_id)) {
@@ -307,15 +307,15 @@ class c_comdef_admin_xml_handler
                     }
                 }
             }
-            
+
             // We get the changes as CSV, then immediately turn them into XML.
             $ret = $this->TranslateCSVToXML($this->get_changes_as_csv($start_date, $end_date, $meeting_id, $user_id, $service_body_id));
             $ret = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<changes xmlns=\"http://".c_comdef_htmlspecialchars($_SERVER['SERVER_NAME'])."\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"".$this->getMainURL()."client_interface/xsd/GetChanges.php\">$ret</changes>";
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to restore a single deleted meeting.
 
@@ -326,38 +326,38 @@ class c_comdef_admin_xml_handler
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = '<h1>NOT AUTHORIZED</h1>';
-        
+
         // First, make sure the user is of the correct general type.
         if ($this->basic_user_validation()) {
             $ret = '<h1>PROGRAM ERROR (ROLLBACK FAILED)</h1>';
-            
+
             $meeting_id = isset($this->http_vars['meeting_id']) && intval($this->http_vars['meeting_id']) ? intval($this->http_vars['meeting_id']) : null;
             $change_id = isset($this->http_vars['change_id']) && intval($this->http_vars['change_id']) ? intval($this->http_vars['change_id']) : null;
-            
+
             if ($meeting_id && $change_id) {
                 $change_objects = c_comdef_server::GetChangesFromIDAndType('c_comdef_meeting', $meeting_id);
-                
+
                 if ($change_objects instanceof c_comdef_changes) {
                     $obj_array = $change_objects->GetChangesObjects();
-            
+
                     if (is_array($obj_array) && count($obj_array)) {
                         foreach ($obj_array as $change) {
                             if ($change->GetID() == $change_id) {
                                 $beforeMeetingObject = $change->GetBeforeObject();
                                 if ($beforeMeetingObject) {
                                     $currentMeetingObject = c_comdef_server::GetOneMeeting($meeting_id);
-                                
+
                                     if (($beforeMeetingObject instanceof c_comdef_meeting) && ($currentMeetingObject instanceof c_comdef_meeting)) {
                                         if ($currentMeetingObject->UserCanEdit() && $beforeMeetingObject->UserCanEdit()) {
                                             if ($change->Rollback()) {
                                                 $meeting_object = c_comdef_server::GetOneMeeting($meeting_id);
-                                            
+
                                                 $ret = $this->get_meeting_data($meeting_id);
                                             }
                                         }
                                     }
                                 }
-                                
+
                                 break;
                             }
                         }
@@ -365,10 +365,10 @@ class c_comdef_admin_xml_handler
                 }
             }
         }
-            
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to restore a single deleted meeting.
 
@@ -379,26 +379,26 @@ class c_comdef_admin_xml_handler
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = '';
-        
+
         // First, make sure the user is of the correct general type.
         if ($this->basic_user_validation()) {
             $meeting_id = isset($this->http_vars['meeting_id']) && intval($this->http_vars['meeting_id']) ? intval($this->http_vars['meeting_id']) : null;
-            
+
             if ($meeting_id) {
                 $change_objects = c_comdef_server::GetChangesFromIDAndType('c_comdef_meeting', $meeting_id);
-                
+
                 if ($change_objects instanceof c_comdef_changes) {
                     $obj_array = $change_objects->GetChangesObjects();
-            
+
                     if (is_array($obj_array) && count($obj_array)) {
                         foreach ($obj_array as $change) {
                             if ($change instanceof c_comdef_change) {
                                 if ($change->GetAfterObject()) {
                                     continue;
                                 }
-                                
+
                                 $unrestored_meeting_object = $change->GetBeforeObject();
-                            
+
                                 if ($unrestored_meeting_object->UserCanEdit()) {
                                     $unrestored_meeting_object->SetPublished(false); // Newly restored meetings are always unpublished.
                                     $unrestored_meeting_object->UpdateToDB();
@@ -422,11 +422,11 @@ class c_comdef_admin_xml_handler
         } else {
             $ret = '<h1>NOT AUTHORIZED</h1>';
         }
-        
+
 
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to delete a meeting.
 
@@ -437,7 +437,7 @@ class c_comdef_admin_xml_handler
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = '';
-        
+
         // First, make sure the user is of the correct general type.
         if ($this->basic_user_validation()) {
             $start_date = (isset($this->http_vars['from_date']) && $this->http_vars['from_date']) ? strtotime($this->http_vars['from_date']) : (isset($this->http_vars['start_date']) && intval($this->http_vars['start_date']) ? intval($this->http_vars['start_date']) : null);
@@ -445,16 +445,16 @@ class c_comdef_admin_xml_handler
             $meeting_id = isset($this->http_vars['meeting_id']) && intval($this->http_vars['meeting_id']) ? intval($this->http_vars['meeting_id']) : null;
             $user_id = isset($this->http_vars['user_id']) && intval($this->http_vars['user_id']) ? intval($this->http_vars['user_id']) : null;
             $service_body_id = null;
-            
+
             if (isset($this->http_vars['service_body_id'])) {
                 $service_body_array = explode(",", $this->http_vars['service_body_id']);
-                
+
                 foreach ($service_body_array as $sb) {
                     $sb_int = intval($sb);
-                    
+
                     if ($sb_int > 0) {
                         $sb_obj = c_comdef_server::GetServiceBodyByIDObj($sb_int);
-                        
+
                         if ($sb_obj instanceof c_comdef_service_body) {
                             if ($sb_obj->UserCanObserve()) {
                                 if (!isset($service_body_id)) {
@@ -469,7 +469,7 @@ class c_comdef_admin_xml_handler
                     }
                 }
             }
-            
+
             // We get the deleted meetings as CSV, then immediately turn them into XML.
             $ret = $this->get_deleted_meetings_as_csv($start_date, $end_date, $meeting_id, $user_id, $service_body_id);
             $ret = $this->TranslateCSVToXML($ret);
@@ -477,7 +477,7 @@ class c_comdef_admin_xml_handler
         } else {
             $ret = '<h1>NOT AUTHORIZED</h1>';
         }
-        
+
         return $ret;
     }
 
@@ -501,22 +501,22 @@ class c_comdef_admin_xml_handler
             $change_objects = c_comdef_server::GetChangesFromIDAndType('c_comdef_meeting', null, $in_start_date, $in_end_date);
             if ($change_objects instanceof c_comdef_changes) {
                 $obj_array = $change_objects->GetChangesObjects();
-            
+
                 if (is_array($obj_array) && count($obj_array)) {
                     set_time_limit(max(30, intval(count($obj_array) / 20))); // Change requests can take a loooong time...
                     $localized_strings = c_comdef_server::GetLocalStrings();
                     require_once(dirname(dirname(dirname(__FILE__))).'/server/config/get-config.php');
                     // These are our columns. This will be our header line.
                     $ret = '"deletion_date_int","deletion_date_string","user_id","user_name","service_body_id","service_body_name","meeting_id","meeting_name","weekday_tinyint","weekday_name","start_time","location_city_subsection","location_municipality","location_province"'."\n";
-                
+
                     // If they specify a Service body, we also look in "child" Service bodies, so we need to produce a flat array of IDs.
                     if (isset($in_sb_id) && $in_sb_id) {
                         // If this is not an array, then we check for children. If it is an array, then we just do exactly what is in the array, regardless of children.
                         if (!is_array($in_sb_id) || !count($in_sb_id)) {
                             global $bmlt_array_gather;
-                    
+
                             $bmlt_array_gather = array();
-                    
+
                             /************************************************//**
                             * This little internal function will simply fill    *
                             * the $bmlt_array_gather array with a linear set of *
@@ -530,15 +530,15 @@ class c_comdef_admin_xml_handler
                             ) {
                                 // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
                                 global $bmlt_array_gather;
-                        
+
                                 if ($in_value instanceof c_comdef_service_body) {
                                     array_push($bmlt_array_gather, $in_value->GetID());
                                 }
                             }
-                        
+
                             $array_to_walk = c_comdef_server::GetServer()->GetNestedServiceBodyArray($in_sb_id);
                             array_walk_recursive($array_to_walk, 'bmlt_at_at');
-                    
+
                             if (is_array($bmlt_array_gather) && count($bmlt_array_gather)) {
                                 $in_sb_id = $bmlt_array_gather;
                             } else {
@@ -546,62 +546,62 @@ class c_comdef_admin_xml_handler
                             }
                         }
                     }
-                    
+
                     $fetched_ids_array = array();
-                    
+
                     foreach ($obj_array as $change) {
                         $date_int = intval($change->GetChangeDate());
                         $date_string = date("Y-m-d H:m:s", $date_int);
-                    
+
                         if ($change instanceof c_comdef_change) {
                             $b_obj = $change->GetBeforeObject();
-                            
+
                             if ($change->GetAfterObject()) {   // We are only interested in deleted meetings. If After exists, it was not a deletion.
                                 continue;
                             }
 
                             $meeting_id = intval($change->GetBeforeObjectID());  // By default, we get the meeting ID from the "before" object.
                             $sb_b = intval(($b_obj instanceof c_comdef_meeting) ? $b_obj->GetServiceBodyID() : 0);
-                            
+
                             $sb_obj = c_comdef_server::GetServiceBodyByIDObj($sb_b);
                             if (($sb_obj instanceof c_comdef_service_body) && $sb_obj->UserCanObserve()) {
                                 $sb_c = intval($change->GetServiceBodyID());
-                            
+
                                 if (in_array($meeting_id, $fetched_ids_array)) {
                                     continue;
                                 }
-                                
+
                                 // If this meeting currently exists, then it doesn't qualify.
                                 if (c_comdef_server::GetMeetingsByID(array ( $meeting_id ))) {
                                     continue;
                                 }
-                                
+
                                 $fetched_ids_array[] = $meeting_id;
-                            
+
                                 // If we are looking for a particular meeting, and this is it, or we don't care, then go ahead.
                                 if ((intval($in_meeting_id) && intval($in_meeting_id) == intval($meeting_id)) || !intval($in_meeting_id)) {
                                     $meeting_name = '';
                                     $user_name = '';
                                     $meeting_town = '';
                                     $meeting_state = '';
-                            
+
                                     // If we are looking for a particular Service body, and this is it, or we don't caer about the Service body, then go ahead.
                                     if (!is_array($in_sb_id) || !count($in_sb_id) || in_array($sb_b, $in_sb_id) || in_array($sb_c, $in_sb_id)) {
                                         $sb_id = (intval($sb_c) ? $sb_c : $sb_b);
-                                
+
                                         $user_id = intval($change->GetUserID());
-                                
+
                                         // If the user was specified, we look for changes by that user only. Otherwise, we don't care.
                                         if ((isset($in_user_id) && $in_user_id && ($in_user_id == $user_id)) || !isset($in_user_id) || !$in_user_id) {
                                             // Get the user that created this change.
                                             $user = c_comdef_server::GetUserByIDObj($user_id);
-                                
+
                                             if ($user instanceof c_comdef_user) {
                                                 $user_name = $user->GetLocalName();
                                             } else {
                                                 $user_name = '????';    // Otherwise, it's a mystery.
                                             }
-            
+
                                             // Using str_replace, because preg_replace is pretty expensive. However, I don't think this buys us much.
                                             if ($b_obj instanceof c_comdef_meeting) {
                                                 $meeting_name = str_replace('"', "'", str_replace("\n", " ", str_replace("\r", " ", $b_obj->GetMeetingDataValue('meeting_name'))));
@@ -609,108 +609,108 @@ class c_comdef_admin_xml_handler
                                                 $meeting_town = str_replace('"', "'", str_replace("\n", " ", str_replace("\r", " ", $b_obj->GetMeetingDataValue('location_municipality'))));
                                                 $meeting_state = str_replace('"', "'", str_replace("\n", " ", str_replace("\r", " ", $b_obj->GetMeetingDataValue('location_province'))));
                                             }
-                                
+
                                             $weekday_tinyint = intval($b_obj->GetMeetingDataValue('weekday_tinyint'));
                                             $weekday_name = $localized_strings["comdef_server_admin_strings"]["meeting_search_weekdays_names"][$weekday_tinyint];
-                                
+
                                             $start_time = $b_obj->GetMeetingDataValue('start_time');
-                                        
+
                                             $sb = c_comdef_server::GetServiceBodyByIDObj($sb_id);
-                                
+
                                             if ($sb instanceof c_comdef_service_body) {
                                                 $sb_name = $sb->GetLocalName();
                                             } else {
                                                 $sb_name = '????';
                                             }
-                                    
+
                                             // We create an array, which we'll implode after we're done. Easy way to create a CSV row.
                                             $change_line = array();
-                                    
+
                                             // Create each column for this row.
                                             if ($date_int) {
                                                 $change_line['deletion_date_int'] = $date_int;
                                             } else {
                                                 $change_line['deletion_date_int'] = 0;
                                             }
-                                
+
                                             if ($date_string) {
                                                 $change_line['deletion_date_string'] = $date_string;
                                             } else {
                                                 $change_line['deletion_date_string'] = '';
                                             }
-                                
+
                                             if ($user_id) {
                                                 $change_line['user_id'] = $user_id;
                                             } else {
                                                 $change_line['user_id'] = 0;
                                             }
-                                
+
                                             if ($user_name) {
                                                 $change_line['user_name'] = $user_name;
                                             } else {
                                                 $change_line['user_name'] = '';
                                             }
-                                
+
                                             if ($sb_id) {
                                                 $change_line['service_body_id'] = $sb_id;
                                             } else {
                                                 $change_line['service_body_id'] = '';
                                             }
-                                
+
                                             if ($sb_name) {
                                                 $change_line['service_body_name'] = $sb_name;
                                             } else {
                                                 $change_line['service_body_name'] = '';
                                             }
-                                
+
                                             if ($meeting_id) {
                                                 $change_line['meeting_id'] = $meeting_id;
                                             } else {
                                                 $change_line['meeting_id'] = 0;
                                             }
-                                
+
                                             if ($meeting_name) {
                                                 $change_line['meeting_name'] = $meeting_name;
                                             } else {
                                                 $change_line['meeting_name'] = '';
                                             }
-                                
+
                                             if ($weekday_tinyint) {
                                                 $change_line['weekday_tinyint'] = $weekday_tinyint;
                                             } else {
                                                 $change_line['weekday_tinyint'] = '';
                                             }
-                                
+
                                             if ($weekday_name) {
                                                 $change_line['weekday_name'] = $weekday_name;
                                             } else {
                                                 $change_line['weekday_name'] = '';
                                             }
-                                
+
                                             if ($start_time) {
                                                 $change_line['start_time'] = $start_time;
                                             } else {
                                                 $change_line['start_time'] = '';
                                             }
-                                
+
                                             if ($meeting_borough) {
                                                 $change_line['location_city_subsection'] = $meeting_borough;
                                             } else {
                                                 $change_line['location_city_subsection'] = '';
                                             }
-                                
+
                                             if ($meeting_town) {
                                                 $change_line['location_municipality'] = $meeting_town;
                                             } else {
                                                 $change_line['location_municipality'] = '';
                                             }
-                                
+
                                             if ($meeting_state) {
                                                 $change_line['location_province'] = $meeting_state;
                                             } else {
                                                 $change_line['location_province'] = '';
                                             }
-                                
+
                                             $ret .= '"'.implode('","', $change_line).'"'."\n";
                                         }
                                     }
@@ -723,7 +723,7 @@ class c_comdef_admin_xml_handler
         } catch (Exception $e) {
             $ret = '<h1>ERROR</h1>';
         }
-            
+
         return $ret;
     }
 
@@ -749,22 +749,22 @@ class c_comdef_admin_xml_handler
             $change_objects = c_comdef_server::GetChangesFromIDAndType($in_change_type, null, $in_start_date, $in_end_date);
             if ($change_objects instanceof c_comdef_changes) {
                 $obj_array = $change_objects->GetChangesObjects();
-            
+
                 if (is_array($obj_array) && count($obj_array)) {
                     set_time_limit(max(30, intval(count($obj_array) / 20))); // Change requests can take a loooong time...
                     $localized_strings = c_comdef_server::GetLocalStrings();
                     require_once(dirname(dirname(dirname(__FILE__))).'/server/config/get-config.php');
                     // These are our columns. This will be our header line.
                     $ret = '"new_meeting","change_id","date_int","date_string","change_type","meeting_id","meeting_name","user_id","user_name","service_body_id","service_body_name","meeting_exists","details"'."\n";
-                
+
                     // If they specify a Service body, we also look in "child" Service bodies, so we need to produce a flat array of IDs.
                     if (isset($in_sb_id) && $in_sb_id) {
                         // If this is not an array, then we check for children. If it is an array, then we just do exactly what is in the array, regardless of children.
                         if (!is_array($in_sb_id) || !count($in_sb_id)) {
                             global $bmlt_array_gather;
-                    
+
                             $bmlt_array_gather = array();
-                    
+
                             /************************************************//**
                             * This little internal function will simply fill    *
                             * the $bmlt_array_gather array with a linear set of *
@@ -778,15 +778,15 @@ class c_comdef_admin_xml_handler
                             ) {
                                 // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
                                 global $bmlt_array_gather;
-                        
+
                                 if ($in_value instanceof c_comdef_service_body) {
                                     array_push($bmlt_array_gather, $in_value->GetID());
                                 }
                             }
-                        
+
                             $array_to_walk = c_comdef_server::GetServer()->GetNestedServiceBodyArray($in_sb_id);
                             array_walk_recursive($array_to_walk, 'bmlt_at_at');
-                    
+
                             if (is_array($bmlt_array_gather) && count($bmlt_array_gather)) {
                                 $in_sb_id = $bmlt_array_gather;
                             } else {
@@ -794,12 +794,12 @@ class c_comdef_admin_xml_handler
                             }
                         }
                     }
-                
+
                     foreach ($obj_array as $change) {
                         $change_type = $change->GetChangeType();
                         $date_int = intval($change->GetChangeDate());
                         $date_string = date("Y-m-d H:m:s", $date_int);
-                    
+
                         if ($change instanceof c_comdef_change) {
                             $b_obj = $change->GetBeforeObject();
                             $a_obj = $change->GetAfterObject();
@@ -807,60 +807,60 @@ class c_comdef_admin_xml_handler
                             $sb_a = intval(($a_obj instanceof c_comdef_meeting) ? $a_obj->GetServiceBodyID() : 0);
                             $sb_b = intval(($b_obj instanceof c_comdef_meeting) ? $b_obj->GetServiceBodyID() : 0);
                             $sb_c = intval($change->GetServiceBodyID());
-                        
+
                             // If the meeting was newly created, then we get the ID from the "after" object.
                             if (!$meeting_id) {
                                 $meeting_id = intval($change->GetAfterObjectID());
                             }
-                        
+
                             // If we are looking for a particular meeting, and this is it, or we don't care, then go ahead.
                             if ((intval($in_meeting_id) && intval($in_meeting_id) == intval($meeting_id)) || !intval($in_meeting_id)) {
                                 $meeting_name = '';
                                 $user_name = '';
-                            
+
                                 // If we are looking for a particular Service body, and this is it, or we don't caer about the Service body, then go ahead.
                                 if (!is_array($in_sb_id) || !count($in_sb_id) || in_array($sb_a, $in_sb_id) || in_array($sb_b, $in_sb_id) || in_array($sb_c, $in_sb_id)) {
                                     $sb_id = (intval($sb_c) ? $sb_c : (intval($sb_b) ? $sb_b : $sb_a));
-                                
+
                                     $user_id = intval($change->GetUserID());
-                                
+
                                     // If the user was specified, we look for changes by that user only. Otherwise, we don't care.
                                     if ((isset($in_user_id) && $in_user_id && ($in_user_id == $user_id)) || !isset($in_user_id) || !$in_user_id) {
                                         // Get the user that created this change.
                                         $user = c_comdef_server::GetUserByIDObj($user_id);
-                                
+
                                         if ($user instanceof c_comdef_user) {
                                             $user_name = $user->GetLocalName();
                                         } else {
                                             $user_name = '????';    // Otherwise, it's a mystery.
                                         }
-            
+
                                         // Using str_replace, because preg_replace is pretty expensive. However, I don't think this buys us much.
                                         if ($b_obj instanceof c_comdef_meeting) {
                                             $meeting_name = str_replace('"', "'", str_replace("\n", " ", str_replace("\r", " ", $b_obj->GetMeetingDataValue('meeting_name'))));
                                         } elseif ($a_obj instanceof c_comdef_meeting) {
                                             $meeting_name = str_replace('"', "'", str_replace("\n", " ", str_replace("\r", " ", $a_obj->GetMeetingDataValue('meeting_name'))));
                                         }
-                                
+
                                         $sb = c_comdef_server::GetServiceBodyByIDObj($sb_id);
-                                
+
                                         if ($sb instanceof c_comdef_service_body) {
                                             $sb_name = $sb->GetLocalName();
                                         } else {
                                             $sb_name = '????';
                                         }
-                                    
+
                                         // We see if the meeting currently exists.
                                         $meeting_exists = 0;
-                                
+
                                         if (c_comdef_server::GetOneMeeting($meeting_id, true)) {
                                             $meeting_exists = 1;
                                         }
-                                    
+
                                         // Get the details of the change.
                                         $details = '';
                                         $desc = $change->DetailedChangeDescription();
-                                
+
                                         if ($desc && isset($desc['details']) && is_array($desc['details'])) {
                                             // We need to prevent double-quotes, as they are the string delimiters, so we replace them with single-quotes.
                                             $details = htmlspecialchars_decode(str_replace('"', "'", str_replace("\n", " ", str_replace("\r", " ", implode(" ", $desc['details'])))), ENT_COMPAT);
@@ -870,77 +870,77 @@ class c_comdef_admin_xml_handler
                                         } else {
                                             $details = htmlspecialchars_decode(str_replace('"', "'", str_replace("\n", " ", str_replace("\r", " ", $desc['overall']))), ENT_COMPAT);
                                         }
-                                    
+
                                         // We create an array, which we'll implode after we're done. Easy way to create a CSV row.
                                         $change_line = array();
-                                    
+
                                         // Create each column for this row.
                                         $change_line["new_meeting"] = ($b_obj instanceof c_comdef_meeting) ? 0 : 1;
-                                        
+
                                         $change_line['change_id'] = $change->GetID();
-                                
+
                                         if ($date_int) {
                                             $change_line['date_int'] = $date_int;
                                         } else {
                                             $change_line['date_int'] = 0;
                                         }
-                                
+
                                         if ($date_string) {
                                             $change_line['date_string'] = $date_string;
                                         } else {
                                             $change_line['date_string'] = '';
                                         }
-                                
+
                                         if ($change_type) {
                                             $change_line['change_type'] = $change_type;
                                         } else {
                                             $change_line['change_type'] = '';
                                         }
-                                
+
                                         if ($meeting_id) {
                                             $change_line['meeting_id'] = $meeting_id;
                                         } else {
                                             $change_line['meeting_id'] = 0;
                                         }
-                                
+
                                         if ($meeting_name) {
                                             $change_line['meeting_name'] = $meeting_name;
                                         } else {
                                             $change_line['meeting_name'] = '';
                                         }
-                                
+
                                         if ($user_id) {
                                             $change_line['user_id'] = $user_id;
                                         } else {
                                             $change_line['user_id'] = 0;
                                         }
-                                
+
                                         if ($user_name) {
                                             $change_line['user_name'] = $user_name;
                                         } else {
                                             $change_line['user_name'] = '';
                                         }
-                                
+
                                         if ($sb_id) {
                                             $change_line['service_body_id'] = $sb_id;
                                         } else {
                                             $change_line['service_body_id'] = '';
                                         }
-                                
+
                                         if ($sb_name) {
                                             $change_line['service_body_name'] = $sb_name;
                                         } else {
                                             $change_line['service_body_name'] = '';
                                         }
-                                
+
                                         $change_line['meeting_exists'] = $meeting_exists;
-                                
+
                                         if ($details) {
                                             $change_line['details'] = $details;
                                         } else {
                                             $change_line['details'] = '';
                                         }
-                                
+
                                         $ret .= '"'.implode('","', $change_line).'"'."\n";
                                     }
                                 }
@@ -955,7 +955,7 @@ class c_comdef_admin_xml_handler
 
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to get all the available fields for adding/modifying meeting data.
 
@@ -966,7 +966,7 @@ class c_comdef_admin_xml_handler
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = '';
-        
+
         // First, make sure the use is of the correct general type.
         if ($this->basic_user_validation()) {
             // Get the template data from the database.
@@ -977,46 +977,46 @@ class c_comdef_admin_xml_handler
             if (is_array($template_data) && count($template_data) && is_array($template_longdata) && count($template_longdata)) {
                 $template_data = array_merge($template_data, $template_longdata);
             }
-            
+
             // $template_data now contains the templates for the meeting data. These are the available "slots" for new values. We need to convert to XML.
-            
+
             foreach ($template_data as $template) {
                 $ret .= '<field_template>';
                     $ret .= '<key>'.c_comdef_htmlspecialchars($template['key']).'</key>';
                     $ret .= '<field_prompt>'.c_comdef_htmlspecialchars($template['field_prompt']).'</field_prompt>';
                     $ret .= '<lang_enum>'.c_comdef_htmlspecialchars($template['lang_enum']).'</lang_enum>';
                     $ret .= '<visibility>'.intval($template['visibility']).'</visibility>';
-                    
+
                 if (isset($template['data_string'])) {
                     $ret .= '<data_string>'.c_comdef_htmlspecialchars($template['data_string']).'</data_string>';
                 }
-                        
+
                 if (isset($template['data_bigint'])) {
                     $ret .= '<data_bigint>'.intval($template['data_bigint']).'</data_bigint>';
                 }
-                        
+
                 if (isset($template['data_double'])) {
                     $ret .= '<data_double>'.intval($template['data_double']).'</data_double>';
                 }
-                        
+
                 if (isset($template['data_longtext'])) {
                     $ret .= '<data_longtext>'.c_comdef_htmlspecialchars($template['data_longtext']).'</data_longtext>';
                 }
-                        
+
                 if (isset($template['data_blob'])) {
                     $ret .= '<data_blob>'.c_comdef_htmlspecialchars(base64_encode($template['data_blob'])).'</data_blob>';
                 }
                 $ret .= '</field_template>';
             }
-            
+
             $ret = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<field_templates xmlns=\"http://".c_comdef_htmlspecialchars($_SERVER['SERVER_NAME'])."\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"".$this->getMainURL()."client_interface/xsd/FieldTemplates.php\">$ret</field_templates>";
         } else {
             $ret = '<h1>NOT AUTHORIZED</h1>';
         }
-            
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to delete an existing meeting. $this->http_vars['meeting_id'] must be set to the meeting ID.
 
@@ -1027,7 +1027,7 @@ class c_comdef_admin_xml_handler
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
-        
+
         // First, make sure the use is of the correct general type.
         if ($this->basic_user_validation()) {
             $meeting_obj = $this->server->GetOneMeeting(intval($this->http_vars['meeting_id']));
@@ -1039,9 +1039,9 @@ class c_comdef_admin_xml_handler
                     $name = c_comdef_htmlspecialchars(str_replace('"', "'", str_replace("\n", " ", str_replace("\r", " ", $meeting_obj->GetMeetingDataValue('meeting_name')))));
                     $weekday = intval($meeting_obj->GetMeetingDataValue('weekday_tinyint'));
                     $start_time = c_comdef_htmlspecialchars($meeting_obj->GetMeetingDataValue('start_time'));
-                    
+
                     $meeting_obj->DeleteFromDB();   // Delete the meeting.
-                    
+
                     // Write out the death certificate.
                     $ret = '<meetingId>'.$id.'</meetingId><meeting_id>'.$id.'</meeting_id><meetingName>'.$name.'</meetingName><meetingServiceBodyId>'.$service_body_id.'</meetingServiceBodyId><meetingStartTime>'.$start_time.'</meetingStartTime><meetingWeekday>'.$weekday.'</meetingWeekday>';
                     $ret = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<deletedMeeting xmlns=\"http://".c_comdef_htmlspecialchars($_SERVER['SERVER_NAME'])."\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"".$this->getMainURL()."client_interface/xsd/DeletedMeeting.php\" id=\"$id\">$ret</deletedMeeting>";
@@ -1054,10 +1054,10 @@ class c_comdef_admin_xml_handler
         } else {
             $ret = '<h1>NOT AUTHORIZED</h1>';
         }
-        
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to modify fields in a meeting (or create a new meeting).
            This requires that the following HTTP parameters be set:
@@ -1074,16 +1074,16 @@ class c_comdef_admin_xml_handler
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = null;
-        
+
         $user_obj = $this->server->GetCurrentUserObj();
         // First, make sure the use is of the correct general type.
         if ($this->basic_user_validation()) {
             $closing_tag = '</changeMeeting>'; // We will usually be changing existing meetings.
             $my_editable_service_bodies = array();
             $thisIsANewMeeting = false; // Set to true for new meetings.
-        
+
             $service_bodies = $this->server->GetServiceBodyArray();
-            
+
             if ($user_obj->GetUserLevel() == _USER_LEVEL_SERVICE_BODY_ADMIN) {  // Must be a Service Body Admin.
                 // We cycle through all the Service bodies, and look for ones in which we have permissions.
                 // We use the Service body IDs to key them in associative arrays.
@@ -1093,26 +1093,26 @@ class c_comdef_admin_xml_handler
                     }
                 }
             }
-            
+
             $new_meeting_id = 0;
             // Get the meeting object, itself.
             if (!intval($this->http_vars['meeting_id'])) {  // Will we be creating a new meeting?
                 $service_bodies = $this->server->GetServiceBodyArray();
-                
+
                 if ($user_obj->GetUserLevel() == _USER_LEVEL_SERVICE_BODY_ADMIN) {  // Must be a Service Body Admin.
                     if (isset($my_editable_service_bodies) && is_array($my_editable_service_bodies) && count($my_editable_service_bodies)) {
                         $service_body_id = 0;
-                    
+
                         // If we are allowed to edit more than one Service body, then we are given a choice. We must supply an ID for the new meeting.
                         if (count($my_editable_service_bodies) > 1) {
                             if (isset($this->http_vars['service_body_id']) && intval($this->http_vars['service_body_id'])) {
                                 $service_body_id = intval($this->http_vars['service_body_id']);
                             } else {
                                 $meeting_fields = $this->http_vars['meeting_field'];
-                                
+
                                 foreach ($meeting_fields as $field) {
                                     list ( $key, $value ) = explode(',', $field);
-                                    
+
                                     if ($key == 'service_body_bigint') {
                                         $service_body_id = intval($value);
                                         break;
@@ -1123,14 +1123,14 @@ class c_comdef_admin_xml_handler
                             {
                             // We have to do this odd dance, because it's an associative array.
                             $keys_1 = array_keys($my_editable_service_bodies);
-                            
+
                             $service_body = $my_editable_service_bodies[$keys_1[0]];
-                            
+
                             if ($service_body instanceof c_comdef_service_body) {
                                 $service_body_id = $service_body->GetID();
                             }
                         }
-                        
+
                         $weekday = 1;   // Default is Sunday
                         $start_time = '20:30:00'; // Default is 8:30 PM
                         $lang = c_comdef_server::GetServer()->GetLocalLang();  // We use whatever the server language is.
@@ -1174,19 +1174,19 @@ class c_comdef_admin_xml_handler
                     // In case we need to add a new field, we get the meeting data template.
                     $template_data = c_comdef_meeting::GetDataTableTemplate();
                     $template_longdata = c_comdef_meeting::GetLongDataTableTemplate();
-    
+
                     // We merge the two tables (data and longdata).
                     if (is_array($template_data) && count($template_data) && is_array($template_longdata) && count($template_longdata)) {
                         $template_data = array_merge($template_data, $template_longdata);
                     }
-            
+
                     // If so, we take the field, and tweak its value.
                     $meeting_fields = $this->http_vars['meeting_field'];
-                
+
                     if (!is_array($meeting_fields)) {
                         $meeting_fields = array ( $meeting_fields );
                     }
-                    
+
                     // We change each of the fields passed in to the new values passed in.
                     foreach ($meeting_fields as $field) {
                         list ( $meeting_field, $value ) = explode(',', $field, 2);
@@ -1194,7 +1194,7 @@ class c_comdef_admin_xml_handler
                             $temp = explode("##-##", $value);
                             $value = $temp[count($temp) - 1];
                         }
-                        
+
                         if (isset($meeting_field) && in_array($meeting_field, $keys)) {
                             switch ($meeting_field) {
                                 case 'id_bigint':   // We don't currently let these get changed.
@@ -1202,12 +1202,12 @@ class c_comdef_admin_xml_handler
                                     $value = null;
                                     $old_value = null;
                                     break;
-                                
+
                                 case 'service_body_bigint':
                                     if (isset($my_editable_service_bodies) && is_array($my_editable_service_bodies) && count($my_editable_service_bodies)) {
                                         $before_id = intval($meeting_obj->GetServiceBodyID());
                                         $after_id = intval($value);
-                                        
+
                                         // Have to be allowed to edit both.
                                         if ($my_editable_service_bodies['sb_'.$before_id] && $my_editable_service_bodies['sb_'.$after_id]) {
                                             $old_value = $meeting_obj->GetServiceBodyID();
@@ -1219,12 +1219,12 @@ class c_comdef_admin_xml_handler
                                         $ret = '<h1>NOT AUTHORIZED</h1>';
                                     }
                                     break;
-                    
+
                                 case 'email_contact':
                                     $old_value = $meeting_obj->GetEmailContact();
                                     $meeting_obj->SetEmailContact(intval($value));
                                     break;
-                    
+
                                 case 'published':
                                     if (!$new_meeting_id) { // New meetings are always unpublished.
                                         $old_value = $meeting_obj->IsPublished();
@@ -1234,7 +1234,7 @@ class c_comdef_admin_xml_handler
                                         $value = 0;
                                     }
                                     break;
-                    
+
                                 case 'weekday_tinyint':
                                     if ((intval($value) > 0) && (intval($value) < 8)) {
                                         $old_value = $meeting_obj->GetMeetingDataValue($meeting_field);
@@ -1242,7 +1242,7 @@ class c_comdef_admin_xml_handler
                                         $data[$meeting_field] = intval($value);
                                     }
                                     break;
-                    
+
                                 case 'longitude':
                                 case 'latitude':
                                     if (floatval($value) != 0.0) {
@@ -1251,7 +1251,7 @@ class c_comdef_admin_xml_handler
                                         $data[$meeting_field] = floatval($value);
                                     }
                                     break;
-                    
+
                                 case 'start_time':
                                 case 'duration_time':
                                 case 'time_zone':
@@ -1259,31 +1259,31 @@ class c_comdef_admin_xml_handler
                                     $data =& $meeting_obj->GetMeetingData();
                                     $data[$meeting_field] = $value;
                                     break;
-                    
+
                                 case 'formats':
                                     // Formats take some extra work, because we store them in the meeting as individual objects, so we create, sort and apply those objects.
                                     $old_value_array = $meeting_obj->GetMeetingDataValue($meeting_field);
                                     $lang = $this->server->GetLocalLang();
                                     $vals = array();
-                                    
+
                                     foreach ($old_value_array as $format) {
                                         if ($format) {
                                             $vals[$format->GetSharedID()] = $format;
                                         }
                                     }
-                                    
+
                                     uksort($vals, array ( 'c_comdef_meeting','format_sorter_simple' ));
-                                    
+
                                     $keys_2 = array();
                                     foreach ($vals as $format) {
                                         $keys_2[] = $format->GetKey();
                                     }
-                                        
+
                                     $old_value = implode(",", $keys_2);
-                                    
+
                                     $formats = explode(",", $value);
                                     $formats_object = $this->server->GetFormatsObj();
-                                    
+
                                     $newVals = array();
                                     foreach ($formats as $key) {
                                         $object = $formats_object->GetFormatByKeyAndLanguage($key, $lang);
@@ -1291,25 +1291,25 @@ class c_comdef_admin_xml_handler
                                             $newVals[$object->GetSharedID()] = $object;
                                         }
                                     }
-                                        
+
                                     uksort($newVals, array ( 'c_comdef_meeting','format_sorter_simple' ));
                                     $data =& $meeting_obj->GetMeetingData();
                                     $data[$meeting_field] = $newVals;
                                     break;
-                                
+
                                 case 'worldid_mixed':
                                     $old_value = $meeting_obj->GetMeetingDataValue($meeting_field);
                                     $data =& $meeting_obj->GetMeetingData();
                                     $data[$meeting_field] = $value;
                                     break;
-                    
+
                                 case 'meeting_name':
                                     $old_value = $meeting_obj->GetMeetingDataValue($meeting_field);
                                     if (!isset($value) || !$value) {
                                         $value = $localized_strings["comdef_server_admin_strings"]["Value_Prompts"]["generic"];
                                     }
                                     // Assuming fallthrough is intentional here, due to lack of break statement?
-                                    
+
                                 default:
                                     $old_value = $meeting_obj->GetMeetingDataValue($meeting_field);
                                     $data =& $meeting_obj->GetMeetingData();
@@ -1318,7 +1318,7 @@ class c_comdef_admin_xml_handler
                                     $meeting_obj->AddDataField($meeting_field, $prompt, $value, null, $visibility, true);
                                     break;
                             }
-                                
+
                             // We only indicate changes.
                             if (isset($meeting_field) && $meeting_field && !($thisIsANewMeeting && !(isset($value) && $value)) && ((isset($old_value) && $old_value) || (isset($value) && $value)) && ($old_value != $value)) {
                                 $ret_temp = '';
@@ -1327,19 +1327,19 @@ class c_comdef_admin_xml_handler
                                 if (!$thisIsANewMeeting && isset($old_value) && $old_value) {
                                     $ret_temp_internal .= '<oldValue>'.c_comdef_htmlspecialchars($old_value).'</oldValue>';
                                 }
-                                    
+
                                 if (isset($value) && $value) {
                                     $ret_temp_internal .= '<newValue>'.c_comdef_htmlspecialchars($value).'</newValue>';
                                 }
-                            
+
                                 $ret_temp .= '<field key="'.c_comdef_htmlspecialchars($meeting_field).'">'.$ret_temp_internal.'</field>';
-                                
+
                                 // We only send back changes that were actually made. This reduces empty response data.
                                 if ($ret_temp_internal) {
                                     $ret .= $ret_temp;
                                 }
                             }
-                                
+
                                 $meeting_field = null;
                         }
                     }
@@ -1347,9 +1347,9 @@ class c_comdef_admin_xml_handler
                         // This can short-circuit the operation.
                     if ($ret != '<h1>NOT AUTHORIZED</h1>') {
                         $meeting_obj->UpdateToDB(); // Save the new data. After this, the meeting has been changed.
-                        
+
                         $ret .= $closing_tag;
-                        
+
                         $ret = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<changeResponse xmlns=\"http://".c_comdef_htmlspecialchars($_SERVER['SERVER_NAME'])."\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"".$this->getMainURL()."client_interface/xsd/ChangeResponse.php\">$ret</changeResponse>";
                     }
                 } else {
@@ -1361,10 +1361,10 @@ class c_comdef_admin_xml_handler
         } else {
             $ret = '<h1>NOT AUTHORIZED</h1>';
         }
-            
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to return meeting information from a search.
 
@@ -1386,7 +1386,7 @@ class c_comdef_admin_xml_handler
         }
 
         require_once(dirname(dirname(dirname(__FILE__))).'/client_interface/csv/search_results_csv.php');
-    
+
         $geocode_results = null;
         $ignore_me = null;
         $meeting_objects = array();
@@ -1405,7 +1405,7 @@ class c_comdef_admin_xml_handler
                 }
             }
         }
-    
+
         if (isset($this->http_vars['data_field_key']) && $this->http_vars['data_field_key']) {
             // At this point, we have everything in a CSV. We separate out just the field we want.
             $temp_keyed_array = array();
@@ -1413,7 +1413,7 @@ class c_comdef_admin_xml_handler
             $keys = array_shift($result);
             $keys = explode("\",\"", trim($keys, '"'));
             $the_keys = explode(',', $this->http_vars['data_field_key']);
-        
+
             $result = array();
             foreach ($result2 as $row) {
                 if ($row) {
@@ -1435,8 +1435,8 @@ class c_comdef_admin_xml_handler
             $the_keys = array_intersect($keys, $the_keys);
             $result2 = '"'.implode('","', $the_keys)."\"\n".implode("\n", $result);
         }
-        
-        
+
+
         $result = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<meetings xmlns=\"http://".c_comdef_htmlspecialchars($_SERVER['SERVER_NAME'])."\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"".$this->getMainURL()."client_interface/xsd/GetSearchResults.php\">";
         $result .= $this->TranslateCSVToXML($result2);
         if ((isset($http_vars['get_used_formats']) || isset($http_vars['get_formats_only'])) && $formats_ar && is_array($formats_ar) && count($formats_ar)) {
@@ -1447,15 +1447,15 @@ class c_comdef_admin_xml_handler
             }
             $result3 = GetFormats($server, $langs, null, $formats_ar);
             $result .= TranslateToXML($result3);
-        
+
             $result .= "</formats>";
         }
-    
+
         $result .= isset($http_vars['get_formats_only']) ? "" : "</meetings>";
-    
+
         return $result;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to return format information.
 
@@ -1466,10 +1466,10 @@ class c_comdef_admin_xml_handler
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = '';
-        
+
         if ($this->basic_user_validation()) {
             $format_ids = array();
-            
+
             // See if we are receiving a request for just specific formats, or if we are being asked for all of them.
             if (isset($this->http_vars['format_id']) && intval(trim($this->http_vars['format_id']))) {
                 $format_ids[] = intval(trim($this->http_vars['format_id']));
@@ -1480,33 +1480,33 @@ class c_comdef_admin_xml_handler
             } else {
                 $format_ids = null;
             }
-            
+
             $lang = $this->server->GetLocalLang();
             if (isset($this->http_vars['lang']) && trim($this->http_vars['lang'])) {
                 $lang = strtolower(trim($this->http_vars['lang']));
             }
-            
+
             $returned_formats = array();    // We will be returning our formats in this.
             $format_objects = $this->server->GetFormatsObj()->GetFormatsByLanguage($lang); // Get all the formats (not just the ones used, but ALL of them).
-            
+
             // Filter for requested formats in the requested language.
             foreach ($format_objects as $format) {
                 if (!$format_ids || in_array(intval($format->GetSharedID()), $format_ids)) {
                     $returned_formats[] = $format;
                 }
             }
-            
+
             // At this point, we have a complete array of just the format[s] that will be returned. Time to make some XML...
             $index = 0;
-            
+
             // We will find out which formats actually appear, somewhere in the DB, and indicate that when we give the info.
             $used_formats = $this->server->GetUsedFormatsArray();
             $used_ids = array();
-            
+
             foreach ($used_formats as $format) {
                 $used_ids[] = intval($format->GetSharedID());
             }
-            
+
             foreach ($returned_formats as $format) {
                 $ret .= '<row sequence_index="'.strval($index++).'">';
                     $id = intval($format->GetSharedID());
@@ -1519,22 +1519,22 @@ class c_comdef_admin_xml_handler
                 if (isset($world_id) && $world_id) {
                     $ret.= '<world_id>'.c_comdef_htmlspecialchars($world_id).'</world_id>';
                 }
-                    
+
                     // If this is used somewehere, we indicate it here.
                 if (in_array($id, $used_ids)) {
                     $ret.= '<format_used_in_database>1</format_used_in_database>';
                 }
-                        
+
                 $ret .= '</row>';
             }
             $ret = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<formats xmlns=\"http://".c_comdef_htmlspecialchars($_SERVER['SERVER_NAME'])."\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"".$this->getMainURL()."client_interface/xsd/GetFormats.php\">$ret</formats>";
         } else {
             $ret = '<h1>NOT AUTHORIZED</h1>';
         }
-            
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to return Service Body information for multiple Service bodies.
 
@@ -1545,10 +1545,10 @@ class c_comdef_admin_xml_handler
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = '';
-        
+
         if ($this->basic_user_validation()) {
             $service_body_ids = array();
-            
+
             // Look to see if the caller is asking for particular Service bodies.
             if (isset($this->http_vars['sb_id']) && $this->http_vars['sb_id']) {
                 if (!is_array($this->http_vars['sb_id'])) {
@@ -1561,7 +1561,7 @@ class c_comdef_admin_xml_handler
                     }
                 }
             }
-            
+
             // If we have a request for individual Service bodies, then we just return those ones.
             if (isset($service_body_ids) && is_array($service_body_ids) && count($service_body_ids)) {
                 foreach ($service_body_ids as $id) {
@@ -1570,22 +1570,22 @@ class c_comdef_admin_xml_handler
             } else // If they are not looking for particular bodies, then we return the whole kit & kaboodle.
                 {
                 $service_bodies = $this->server->GetServiceBodyArray();
-            
+
                 foreach ($service_bodies as $service_body) {
                     if (isset($this->http_vars['flat']) || !$service_body->GetOwnerIDObject()) {    // We automatically include top-level Service bodies here, and let ones with parents sort themselves out.
                         $ret .= $this->process_service_body_info_request($service_body->GetID());
                     }
                 }
             }
-        
+
             $ret = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<service_bodies xmlns=\"http://".c_comdef_htmlspecialchars($_SERVER['SERVER_NAME'])."\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"".$this->getMainURL()."client_interface/xsd/HierServiceBodies.php\">$ret</service_bodies>";
         } else {
             $ret = '<h1>NOT AUTHORIZED</h1>';
         }
-            
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to return Service Body information.
 
@@ -1602,7 +1602,7 @@ class c_comdef_admin_xml_handler
             if (!in_array($in_service_body_id, $this->handled_service_body_ids)) {
                 $this->handled_service_body_ids[] = $in_service_body_id;
                 $service_body = $this->server->GetServiceBodyByIDObj($in_service_body_id);
-            
+
                 if (isset($service_body) && ($service_body instanceof c_comdef_service_body)) {
                     // Everyone gets the type, URI, name, description and parent Service body.
                     $name = $service_body->GetLocalName();
@@ -1616,22 +1616,22 @@ class c_comdef_admin_xml_handler
                     $parent_service_body_type = "";
 
                     $parent_service_body = $service_body->GetOwnerIDObject();
-                
+
                     if (isset($parent_service_body) && $parent_service_body) {
                         $parent_service_body_id = intval($parent_service_body->GetID());
                         $parent_service_body_name = $parent_service_body->GetLocalName();
                         $parent_service_body_type = $parent_service_body->GetSBType();
                     }
-                
+
                     $principal_user = $service_body->GetPrincipalUserObj();
                     $principal_user_id = intval($principal_user->GetID());
-                
+
                     // Scan for our various editors.
                     $guest_editors = $this->server->GetUsersByLevelObj(_USER_LEVEL_OBSERVER, true);  // Observer or greater.
                     $service_body_editors = array();
                     $meeting_list_editors = array();
                     $observers = array();
-                
+
                     foreach ($guest_editors as $editor) {
                         if ($service_body->UserCanEdit($editor)) {   // We will have at least one of these, as the principal user needs to be listed.
                             array_push($service_body_editors, $editor);
@@ -1641,30 +1641,30 @@ class c_comdef_admin_xml_handler
                             array_push($observers, $editor);
                         }
                     }
-                
+
                     // Scan for direct descendant child Service bodies.
                     $children = array();
                     $service_bodies = $this->server->GetServiceBodyArray();
-                
+
                     foreach ($service_bodies as $child) {
                         if ($child->IsOwnedBy($in_service_body_id, true)) {
                             $children[] = $child;
                         }
                     }
-                
+
                     // We check to see which editors are mentioned in this Service body.
                     $guest_editors = $service_body->GetEditors();
-                
+
                     // See if we have rights to edit this Service body. Just for the heck of it, we check the user level (not really necessary, but belt and suspenders).
                     $this_user_can_edit_the_body = ($this->server->GetCurrentUserObj()->GetUserLevel() == _USER_LEVEL_SERVICE_BODY_ADMIN) && $service_body->UserCanEdit();
-                
+
                     $contact_email = null;
-                
+
                     // Service Body Admins (with permission for the body) get more info.
                     if ($this_user_can_edit_the_body) {
                         $contact_email = $service_body->GetContactEmail();
                     }
-                    
+
                     // At this point, we have all the information we need to build the response XML.
                     $ret = '<service_body id="'.c_comdef_htmlspecialchars($in_service_body_id).'" name="'.c_comdef_htmlspecialchars($name).'" type="'.c_comdef_htmlspecialchars($type).'">';
                         $ret .= '<service_body_type>'.c_comdef_htmlspecialchars($this->my_localized_strings['service_body_types'][$type]).'</service_body_type>';
@@ -1683,7 +1683,7 @@ class c_comdef_admin_xml_handler
                     if ($this_user_can_edit_the_body && isset($contact_email) && $contact_email) {
                         $ret .= '<contact_email>'.c_comdef_htmlspecialchars($contact_email).'</contact_email>';
                     }
-                    
+
                         $ret .= '<editors>';
                     if (isset($service_body_editors) && is_array($service_body_editors) && count($service_body_editors)) {
                         // We will have at least one of these (the principal user).
@@ -1695,7 +1695,7 @@ class c_comdef_admin_xml_handler
                         }
                                 $ret .= '</service_body_editors>';
                     }
-                        
+
                             // These are users that can't manipulate the Service body, but can edit meetings.
                     if (isset($meeting_list_editors) && is_array($meeting_list_editors) && count($meeting_list_editors)) {
                         $ret .= '<meeting_list_editors>';
@@ -1705,7 +1705,7 @@ class c_comdef_admin_xml_handler
                         }
                                 $ret .= '</meeting_list_editors>';
                     }
-                        
+
                             // These are users that can only see hidden fields in meetings.
                     if (isset($observers) && is_array($observers) && count($observers)) {
                         $ret .= '<observers>';
@@ -1716,7 +1716,7 @@ class c_comdef_admin_xml_handler
                                 $ret .= '</observers>';
                     }
                         $ret .= '</editors>';
-                
+
                         // If this is a hierarchical response, we embed the children as XML service_body elements. Otherwise, we list them as simple catalog elements.
                     if (!isset($this->http_vars['flat']) && isset($children) && is_array($children) && count($children)) {
                         $ret .= "<service_bodies>";
@@ -1738,10 +1738,10 @@ class c_comdef_admin_xml_handler
         } else {
             $ret = '<h1>NOT AUTHORIZED</h1>';
         }
-            
+
         return $ret;
     }
-    
+
     /********************************************************************************************************//**
     \brief This fulfills a user request to report the rights for the logged-in user.
 
@@ -1753,12 +1753,12 @@ class c_comdef_admin_xml_handler
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = '';
         $service_bodies = $this->server->GetServiceBodyArray();
-        
+
         // We will fill these three arrays, depending on the users' rights for a given Service body.
         $my_meeting_observer_service_bodies = array();
         $my_meeting_editor_service_bodies = array();
         $my_editable_service_bodies = array();
-        
+
         $user_obj = $this->server->GetCurrentUserObj();
         if ($this->basic_user_validation()) {
             // We cycle through all the Service bodies, and look for ones in which we have permissions.
@@ -1776,19 +1776,19 @@ class c_comdef_admin_xml_handler
                 }
             }
             // Now, we grant rights to Service bodies that are implicit from other rights (for example, a Service Body Admin can also observe and edit meetings).
-            
+
             // A full Service Body Admin can edit meetings in that Service body.
             foreach ($my_editable_service_bodies as $service_body) {
                 $my_meeting_editor_service_bodies['sb_'.$service_body->GetID()] = $service_body;
             }
-            
+
             // An editor (whether an admin or a "guest") also has observe rights.
             foreach ($my_meeting_editor_service_bodies as $service_body) {
                 $my_meeting_observer_service_bodies['sb_'.$service_body->GetID()] = $service_body;
             }
-            
+
             // At this point, we have 3 arrays (or fewer), filled with Service bodies that we have rights on. It is entirely possible that only one of them could be filled, and it may only have one member.
-            
+
             // We start to construct the XML filler.
             foreach ($service_bodies as $service_body) {
                 // If we can observe, then we have at least one permission for this Service body.
@@ -1812,7 +1812,7 @@ class c_comdef_admin_xml_handler
         } else {
             $ret = '<h1>NOT AUTHORIZED</h1>';
         }
-        
+
         return $ret;
     }
 
@@ -1857,7 +1857,7 @@ class c_comdef_admin_xml_handler
         $keys = array_shift($in_csv_data);
         $keys = rtrim(ltrim($keys, '"'), '",');
         $keys = preg_split('/","/', $keys);
-    
+
         foreach ($in_csv_data as $row) {
             if ($row) {
                 $line = null;

--- a/src/legacy/local_server/server_admin/c_comdef_login.php
+++ b/src/legacy/local_server/server_admin/c_comdef_login.php
@@ -75,7 +75,7 @@ if (isset($_GET['bad_login_form'])) {
 $user_obj = $t_server->GetCurrentUserObj();
 if (is_null($user_obj)) {
     echo c_comdef_LoginForm($t_server);
-} elseif (!($user_obj instanceof c_comdef_user) || ($user_obj->GetUserLevel() == _USER_LEVEL_DISABLED)) {
+} elseif (!($user_obj instanceof c_comdef_user) || ($user_obj->GetUserLevel() == _USER_LEVEL_DEACTIVATED)) {
     // If the login is invalid, we terminate the whole kit and kaboodle, and inform the user they are persona non grata.
     die('<div class="c_comdef_not_auth_container_div"><div class="c_comdef_not_auth_div"><h1 class="c_comdef_not_auth_1">'.c_comdef_htmlspecialchars($localized_strings['comdef_server_admin_strings']['not_auth_1']).'</h1><h2 class="c_comdef_not_auth_2">'.c_comdef_htmlspecialchars($localized_strings['comdef_server_admin_strings']['not_auth_2']).'</h2></div></div></body></html>');
 } else {

--- a/src/legacy/local_server/server_admin/json.php
+++ b/src/legacy/local_server/server_admin/json.php
@@ -57,7 +57,7 @@ if (isset($g_enable_semantic_admin) && ($g_enable_semantic_admin == true)) {
 
     if ($server instanceof c_comdef_server) {
         $user_obj = $server->GetCurrentUserObj();
-        if (!($user_obj instanceof c_comdef_user) || ($user_obj->GetUserLevel() == _USER_LEVEL_DISABLED) || ($user_obj->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN) || ($user_obj->GetID() == 1)) {
+        if (!($user_obj instanceof c_comdef_user) || ($user_obj->GetUserLevel() == _USER_LEVEL_DEACTIVATED) || ($user_obj->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN) || ($user_obj->GetID() == 1)) {
             c_comdef_LogoutUser();
             die('NOT AUTHORIZED');
         }

--- a/src/legacy/local_server/server_admin/xml.php
+++ b/src/legacy/local_server/server_admin/xml.php
@@ -55,7 +55,7 @@ if (isset($g_enable_semantic_admin) && ($g_enable_semantic_admin == true)) {
 
     if ($server instanceof c_comdef_server) {
         $user_obj = $server->GetCurrentUserObj();
-        if (!($user_obj instanceof c_comdef_user) || $user_obj->GetUserLevel() == _USER_LEVEL_DISABLED || $user_obj->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN || $user_obj->GetID() == 1) {
+        if (!($user_obj instanceof c_comdef_user) || $user_obj->GetUserLevel() == _USER_LEVEL_DEACTIVATED || $user_obj->GetUserLevel() == _USER_LEVEL_SERVER_ADMIN || $user_obj->GetID() == 1) {
             c_comdef_LogoutUser();
             die('<h1>NOT AUTHORIZED</h1>');
         }

--- a/src/legacy/server/c_comdef_server.class.php
+++ b/src/legacy/server/c_comdef_server.class.php
@@ -1311,7 +1311,7 @@ class c_comdef_server
             $user_array = $users_obj->GetUsersArray();
 
             foreach ($user_array as &$user_obj) {
-                if (($user_obj->GetUserLevel() > 0) && ($in_include_disabled || ($user_obj->GetUserLevel() != _USER_LEVEL_DISABLED)) && (($user_obj->GetUserLevel() == $in_user_level_bigint) || ($in_or_higher && ($user_obj->GetUserLevel() < $in_user_level_bigint)))) {
+                if (($user_obj->GetUserLevel() > 0) && ($in_include_disabled || ($user_obj->GetUserLevel() != _USER_LEVEL_DEACTIVATED)) && (($user_obj->GetUserLevel() == $in_user_level_bigint) || ($in_or_higher && ($user_obj->GetUserLevel() < $in_user_level_bigint)))) {
                     $ret_array[$user_obj->GetID()] = $user_obj;
                 }
             }

--- a/src/legacy/server/classes/c_comdef_meeting.class.php
+++ b/src/legacy/server/classes/c_comdef_meeting.class.php
@@ -1750,7 +1750,7 @@ class c_comdef_meeting extends t_comdef_world_type implements i_comdef_db_stored
         if ($in_user_object instanceof c_comdef_user) {
             $in_user_object->RestoreFromDB();   // The reason you do this, is to ensure that the user wasn't modified "live." It's a security precaution.
 
-            if (($in_user_object->GetUserLevel() != _USER_LEVEL_SERVER_ADMIN) && ($in_user_object->GetUserLevel() != _USER_LEVEL_DISABLED) && (($in_user_object->GetUserLevel() == _USER_LEVEL_EDITOR) || ($in_user_object->GetUserLevel() == _USER_LEVEL_SERVICE_BODY_ADMIN))) {
+            if (($in_user_object->GetUserLevel() != _USER_LEVEL_SERVER_ADMIN) && ($in_user_object->GetUserLevel() != _USER_LEVEL_DEACTIVATED) && (($in_user_object->GetUserLevel() == _USER_LEVEL_EDITOR) || ($in_user_object->GetUserLevel() == _USER_LEVEL_SERVICE_BODY_ADMIN))) {
                 // If there is an existing object, then we can't make changes unless it's allowed in the existing object.
                 $current_obj = c_comdef_server::GetServer()->GetOneMeeting($this->GetID());
 

--- a/src/legacy/server/classes/c_comdef_user.class.php
+++ b/src/legacy/server/classes/c_comdef_user.class.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__)."/../shared/classes/comdef_utilityclasses.inc.php
 define("_USER_LEVEL_SERVER_ADMIN", 1);
 define("_USER_LEVEL_SERVICE_BODY_ADMIN", 2);
 define("_USER_LEVEL_EDITOR", 3);
-define("_USER_LEVEL_DISABLED", 4);
+define("_USER_LEVEL_DEACTIVATED", 4);
 define("_USER_LEVEL_OBSERVER", 5);
 
 /***********************************************************************/
@@ -43,7 +43,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 {
     /// An integer, containing the unique ID of this user.
     private $_id_bigint = null;
-    
+
     /**
         \brief An integer, containing the user level.
 
@@ -72,22 +72,22 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                     data items in meetings for the Service bodies to which it has been attached..
     */
     private $_user_level_tinyint = null;
-    
+
     /// A string, containing the user's email address.
     private $_email_address_string = null;
-    
+
     /// A string, containing the user's login ID.
     private $_login_string = null;
-    
+
     /// A string, containing the user's encrypted password.
     private $_password_string = null;
-    
+
     /// A time date, indicating the last time the user was active. This will be useful for administration.
     private $_last_access = null;
 
     /// An integer containing the id of the user that owns this user.
     private $_owner_id_bigint = -1;
-    
+
     /*******************************************************************/
     /** \brief Updates or adds this instance to the database.
 
@@ -103,20 +103,20 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
     ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = false;
-            
+
         $cur_user = c_comdef_server::GetCurrentUserObj();
-        
+
         if ($cur_user instanceof c_comdef_user) {
             $cur_user_clone = clone ( $cur_user );  // This little dance is to make sure that the live object wasn't changed.
             $cur_user_clone->RestoreFromDB();
-        
+
             if ($cur_user_clone->UserCanEdit($cur_user)) {
                 // We take a snapshot of the user as it currently sits in the database as a "before" image.
                 $before = null;
                 $before_id = null;
                 $before_lang = null;
                 $before_obj = c_comdef_server::GetOneUser($this->GetID());
-                
+
                 if ($before_obj instanceof c_comdef_user) {
                     $before_obj_clone = clone $before_obj;
                     $before_obj_clone->RestoreFromDB();
@@ -127,7 +127,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                 }
 
                 $this->DeleteFromDB_NoRecord();
-                
+
                 try {
                     $update = array();
                     if ($this->_id_bigint) {
@@ -135,13 +135,13 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                     }
                     array_push($update, $this->_user_level_tinyint);
                     array_push($update, $this->_email_address_string);
-                    
+
                     if (null != $new_login) {
                         $this->SetLogin($new_login);
                     }
 
                     array_push($update, $this->_login_string);
-                    
+
                     if (null != $new_pass) {
                         $this->SetNewPassword($new_pass);
                     }
@@ -152,7 +152,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                     array_push($update, $this->GetLocalDescription());
                     array_push($update, $this->GetLocalLang());
                     array_push($update, $this->GetOwnerID());
-                    
+
                     $sql = "INSERT INTO `".c_comdef_server::GetUserTableName_obj()."` (";
                     if ($this->_id_bigint) {
                         $sql .= "`id_bigint`,";
@@ -171,7 +171,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                             $this->_id_bigint = intval($rows[0]['last_insert_id()']);
                         }
                     }
-                    
+
                     $after = $this->SerializeObject();
                     $after_id = $this->GetID();
                     $after_lang = $this->GetLocalLang();
@@ -180,7 +180,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                     $ret = true;
                 } catch (Exception $ex) {
                     global  $_COMDEF_DEBUG;
-                    
+
                     if ($_COMDEF_DEBUG) {
                         echo "Exception Thrown in c_comdef_user::UpdateToDB()!<br />";
                         var_dump($ex);
@@ -189,10 +189,10 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                 }
             }
         }
-        
+
         return $ret;
     }
-    
+
     /*******************************************************************/
     /** \brief Deletes this instance from the database without creating a change record.
 
@@ -205,7 +205,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = false;
-        
+
         if ($this->UserCanEdit()) {
             try {
                 $sql = "DELETE FROM `".c_comdef_server::GetUserTableName_obj()."` WHERE id_bigint=?";
@@ -213,7 +213,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                 $ret = true;
             } catch (Exception $ex) {
                 global  $_COMDEF_DEBUG;
-                
+
                 if ($_COMDEF_DEBUG) {
                     echo "Exception Thrown in c_comdef_user::DeleteFromDB()!<br />";
                     var_dump($ex);
@@ -221,10 +221,10 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                 throw ( $ex );
             }
         }
-        
+
         return $ret;
     }
-    
+
     /*******************************************************************/
     /** \brief Deletes this instance from the database, and creates a change record.
 
@@ -237,16 +237,16 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = false;
-        
+
         $user = c_comdef_server::GetCurrentUserObj();
-        
+
         if ($this->UserCanEdit($user)) {
             // We take a snapshot of the user as it currently sits in the database as a "before" image.
             $before = null;
             $before_id = null;
             $before_lang = null;
             $before_obj = c_comdef_server::GetOneUser($this->GetID());
-            
+
             if ($before_obj instanceof c_comdef_user) {
                 $before = $before_obj->SerializeObject();
                 $before_id = $before_obj->GetID();
@@ -255,12 +255,12 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
             }
 
             $ret = $this->DeleteFromDB_NoRecord();
-            
+
             if ($ret) {
                 c_comdef_server::AddNewChange($user->GetID(), 'comdef_change_type_delete', $this->GetID(), $before, null, 'c_comdef_user', $before_id, null, $before_lang, null);
             }
         }
-        
+
         return $ret;
     }
 
@@ -286,7 +286,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
 
         return $ret;
     }
-    
+
     /*******************************************************************/
     /** \brief Updates this instance to the current values in the DB
         (replacing current values of the instance).
@@ -318,7 +318,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
             }
         } catch (Exception $ex) {
             global  $_COMDEF_DEBUG;
-            
+
             if ($_COMDEF_DEBUG) {
                 echo "Exception Thrown in c_comdef_user::RestoreFromDB()!<br />";
                 var_dump($ex);
@@ -326,7 +326,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
             throw ( $ex );
         }
     }
-    
+
     /*******************************************************************/
     /** \brief The initial setup call for the class. If you send in values,
         the object will set itself up to use them.
@@ -377,7 +377,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
         $this->SetLocalLang($in_lang_enum);
         $this->SetLocalName($in_name_string);
         $this->SetLocalDescription($in_description_string);
-        
+
         // Set the local values.
         $this->_id_bigint = $in_id_bigint;
         $this->_user_level_tinyint = $in_user_level_tinyint;
@@ -387,7 +387,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
         $this->_owner_id_bigint = $in_owner_id_bigint;
         $this->_last_access = $in_last_access;
     }
-    
+
     /*******************************************************************/
     /** \brief Returns true if the user is enabled (levels 1-3)
 
@@ -397,9 +397,9 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
     public function IsEnabled()
     {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-        return ($this->_user_level_tinyint > 0) && ($this->_user_level_tinyint != _USER_LEVEL_DISABLED);
+        return ($this->_user_level_tinyint > 0) && ($this->_user_level_tinyint != _USER_LEVEL_DEACTIVATED);
     }
-    
+
     /*******************************************************************/
     /** \brief Accessor - Returns the user ID as an integer.
 
@@ -411,7 +411,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         return $this->_id_bigint;
     }
-    
+
     /*******************************************************************/
     /** \brief Accessor - Sets the user ID as an integer.
     */
@@ -479,7 +479,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
         $this->RestoreFromDB();
         return $this->_user_level_tinyint;
     }
-    
+
     /*******************************************************************/
     /** \brief Accessor - Sets the user level.
         Attempts to set the user level to 1 for users other than User 1 will fail.
@@ -521,7 +521,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
             return true;
         }
     }
-    
+
     /*******************************************************************/
     /** \brief Accessor - Returns the user email address.
 
@@ -533,7 +533,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         return $this->_email_address_string;
     }
-    
+
     /*******************************************************************/
     /** \brief Accessor - Sets the user email address.
     */
@@ -544,7 +544,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $this->_email_address_string = $in_email_address_string;
     }
-    
+
     /*******************************************************************/
     /** \brief Accessor - Returns the user login.
 
@@ -556,7 +556,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         return $this->_login_string;
     }
-    
+
     /*******************************************************************/
     /** \brief Accessor - Sets the userlogin.
 
@@ -568,18 +568,18 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
     ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = false;
-        
+
         if ($in_login_string) {
             $users_obj = c_comdef_server::GetServer()->GetServerUsersObj();
-            
+
             // We are not allowed to select a login that is already in use. The comparison
             // is case-insensitive.
             if ($users_obj instanceof c_comdef_users) {
                 $obj_array = $users_obj->GetUsersArray();
-                
+
                 if (is_array($obj_array)) {
                     $ret = true;
-                    
+
                     foreach ($obj_array as $one_user) {
                         // We don't worry if this is our own object.
                         if ($one_user->GetID() != $this->GetID()) {
@@ -589,7 +589,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                             }
                         }
                     }
-                    
+
                     // If we went through without a match, we change the login.
                     if ($ret) {
                         $this->_login_string = $in_login_string;
@@ -597,10 +597,10 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                 }
             }
         }
-        
+
         return $ret;
     }
-    
+
     /*******************************************************************/
     /** \brief See if this is the given user by login and password.
 
@@ -616,17 +616,17 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
     ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $login_match = (strcasecmp($in_login_string, $this->GetLogin()) == 0);
-        
+
         // See if we need to encrypt the password.
         if ($in_pw_raw) {
             $password_match = password_verify($in_password_string, $this->GetPassword());
         } else {
             $password_match = hash_equals($this->GetPassword(), $in_password_string);
         }
-        
+
         return $login_match && $password_match;
     }
-    
+
     /*******************************************************************/
     /** \brief Accessor - Returns the user password, in encrypted form.
 
@@ -638,7 +638,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         return $this->_password_string;
     }
-    
+
     /*******************************************************************/
     /** \brief Accessor - Sets the password, as an encrypted string.
     */
@@ -653,7 +653,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
             return null;
         }
     }
-    
+
     /*******************************************************************/
     /** \brief Accessor - Sets the password, encrypting it.
 
@@ -679,7 +679,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
             return null;
         }
     }
-    
+
     /*******************************************************************/
     /** \brief Accessor - Gets the last access time.
 
@@ -691,7 +691,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         return $this->_last_access;
     }
-    
+
     /*******************************************************************/
     /** \brief Simply sets the last access time to now.
     */
@@ -702,7 +702,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $this->_last_access = (null != $in_time) ? $in_time : time();
     }
-    
+
     /*******************************************************************/
     /** \brief Returns a storable serialization of the object, as a string.
 
@@ -727,10 +727,10 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                                 $this->_owner_id_bigint,
                                 $this->GetLocalLang()
                                 );
-        
+
         return serialize($serialize_array);
     }
-    
+
     /*******************************************************************/
     /** \brief This takes the serialized table, and instantiates a
         new object from it.
@@ -754,10 +754,10 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
                 $_local_description,
                 $_owner_id_bigint,
                 $_local_lang ) = unserialize($serialized_string);
-                
+
         return new c_comdef_user($in_parent, $_id_bigint, $_user_level_tinyint, $_email_address_string, $_login_string, $_password_string, $_local_lang, $_local_name, $_local_description, $_owner_id_bigint, $_last_access);
     }
-    
+
     /*******************************************************************/
     /** \brief Test to see if a user is allowed to edit an instance (change the data).
 
@@ -769,12 +769,12 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
     ) {
         // phpcs:enable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
         $ret = false;
-        
+
         // We load the server user if one wasn't supplied.
         if (null == $in_user_object) {
             $in_user_object = c_comdef_server::GetCurrentUserObj();
         }
-        
+
         // We clone, in case changes have been made, and we don't want to screw them up.
         $in_user_clone = clone $in_user_object;
 
@@ -782,7 +782,7 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
         if ($in_user_clone instanceof c_comdef_user) {
             $in_user_clone->RestoreFromDB();    // The reason you do this, is to ensure that the user wasn't modified "live." It's a security precaution.
             // Server admins can edit users. Service body administrators can edit users they own. Any user can edit itself.
-            if ($in_user_clone->GetUserLevel() == _USER_LEVEL_DISABLED) {
+            if ($in_user_clone->GetUserLevel() == _USER_LEVEL_DEACTIVATED) {
                 return false;
             }
 
@@ -801,10 +801,10 @@ class c_comdef_user extends t_comdef_local_type implements i_comdef_db_stored, i
             if (c_comdef_server::IsUserServiceBodyAdmin() && $this->GetOwnerID() == c_comdef_server::GetCurrentUserObj()->GetID()) {
                 return true;
             }
-            
+
             $in_user_clone = null;
         }
-        
+
         return $ret;
     }
 }

--- a/src/legacy/server/shared/classes/comdef_utilityclasses.inc.php
+++ b/src/legacy/server/shared/classes/comdef_utilityclasses.inc.php
@@ -286,7 +286,7 @@ function c_comdef_admin_bar(
         include(dirname(__FILE__).'/../../../server/config/get-config.php');
 
         $user_obj = $server->GetCurrentUserObj();
-        if (($user_obj instanceof c_comdef_user) && ($user_obj->GetUserLevel() != _USER_LEVEL_DISABLED) && ($user_obj->GetUserLevel() != _USER_LEVEL_OBSERVER)) {
+        if (($user_obj instanceof c_comdef_user) && ($user_obj->GetUserLevel() != _USER_LEVEL_DEACTIVATED) && ($user_obj->GetUserLevel() != _USER_LEVEL_OBSERVER)) {
             $left_link = '&nbsp;';
             $middle_link = '&nbsp;';
 

--- a/src/resources/js/localization.ts
+++ b/src/resources/js/localization.ts
@@ -28,7 +28,7 @@ export const strings = new LocalizedStrings({
     adminTitle: 'Administrator',
     serviceBodyAdminTitle: 'Service Body Administrator',
     observerTitle: 'Service Body Observer',
-    disabledUserTitle: 'Disabled User',
+    deactivatedUserTitle: 'Deactivated User',
     noUsers: '- None -',
   },
   de: {
@@ -41,7 +41,7 @@ export const strings = new LocalizedStrings({
     userIsATitle: 'Benutzer ist ein:',
     descriptionTitle: 'Beschreibung:',
     deleteUserTitle: 'Lösche diesen Benutzer',
-    disabledUserTitle: 'Deaktivierter Benutzer',
+    deactivatedUserTitle: 'Deaktivierter Benutzer',
     noUsers: '- Keine -',
   },
   dk: {
@@ -58,7 +58,7 @@ export const strings = new LocalizedStrings({
     ownedByTitle: 'Ejet Af:',
     deleteUserTitle: 'Slet Denne Bruger',
     observerTitle: 'Service enhed overvåger',
-    disabledUserTitle: 'Deaktiveret bruger',
+    deactivatedUserTitle: 'Deaktiveret bruger',
     noUsers: '- None -',
   },
   es: {
@@ -78,7 +78,7 @@ export const strings = new LocalizedStrings({
     adminTitle: 'Administrador',
     serviceBodyAdminTitle: 'Administrador de cuerpo de servicio',
     observerTitle: 'Observador de cuerpo de servicio',
-    disabledUserTitle: 'Usario discapacitado',
+    deactivatedUserTitle: 'Usario desactivado', // TODO: check that this translation is correct
     noUsers: '- None -',
   },
   fa: {},
@@ -98,7 +98,7 @@ export const strings = new LocalizedStrings({
     adminTitle: 'Administrateur',
     serviceBodyAdminTitle: "Administrateur d'une structure de service",
     observerTitle: 'Observateur',
-    disabledUserTitle: 'Désactiver utilisateur',
+    deactivatedUserTitle: 'Utilisateur désactivé', // TODO: check that this translation is correct
     noUsers: '- None -',
   },
   it: {
@@ -115,7 +115,7 @@ export const strings = new LocalizedStrings({
     adminTitle: 'Amministratore',
     serviceBodyAdminTitle: 'Amministratore della struttura di servizio',
     observerTitle: 'Osservatore nella struttura di servizio',
-    disabledUserTitle: 'Disattiva utente',
+    deactivatedUserTitle: 'Utente disattivato', // TODO: check that this translation is correct
     noUsers: '- None -',
   },
   pl: {
@@ -134,7 +134,7 @@ export const strings = new LocalizedStrings({
     deleteUserTitle: 'Usuń tego użytkownika',
     serviceBodyAdminTitle: 'Administrator organu służb',
     observerTitle: 'Obserwator z organu służb',
-    disabledUserTitle: 'Dezaktywowany użytkownik',
+    deactivatedUserTitle: 'Dezaktywowany użytkownik',
     noUsers: '- None -',
   },
   pt: {
@@ -154,7 +154,7 @@ export const strings = new LocalizedStrings({
     adminTitle: 'Administrador',
     serviceBodyAdminTitle: 'Administrador de corpo de serviço',
     observerTitle: 'Observador',
-    disabledUserTitle: 'Usuário desativado',
+    deactivatedUserTitle: 'Usuário desativado', // TODO: check that this translation is correct
     noUsers: '- None -',
   },
   ru: {
@@ -174,7 +174,7 @@ export const strings = new LocalizedStrings({
     adminTitle: 'Администратор',
     serviceBodyAdminTitle: 'Администратор орагана обслуживания',
     observerTitle: 'Наблюдатель органа обслуживания',
-    disabledUserTitle: 'Инвалидный пользователь',
+    deactivatedUserTitle: 'Деактивированный пользователь', // TODO: check that this translation is correct
     noUsers: '- None -',
   },
   sv: {
@@ -191,7 +191,7 @@ export const strings = new LocalizedStrings({
     adminTitle: 'Administratör',
     serviceBodyAdminTitle: 'Serviceenhet Administratör',
     observerTitle: 'Serviceenhet övervakare',
-    disabledUserTitle: 'Inaktivera användare',
+    deactivatedUserTitle: 'Avaktiverad användare', // TODO: check that this translation is correct
     noUsers: '- None -',
   },
 });

--- a/src/resources/js/pages/Users.tsx
+++ b/src/resources/js/pages/Users.tsx
@@ -333,7 +333,7 @@ export const Users = () => {
                   >
                     <MenuItem value='serviceBodyAdmin'>{strings.serviceBodyAdminTitle}</MenuItem>
                     <MenuItem value='observer'>{strings.observerTitle}</MenuItem>
-                    <MenuItem value='disabled'>{strings.disabledUserTitle}</MenuItem>
+                    <MenuItem value='deactivated'>{strings.deactivatedUserTitle}</MenuItem>
                   </Select>
                 )}
               />

--- a/src/tests/Feature/Admin/FormatPermissionsTest.php
+++ b/src/tests/Feature/Admin/FormatPermissionsTest.php
@@ -25,9 +25,9 @@ class FormatPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testIndexAsDisabled()
+    public function testIndexAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->get('/api/v1/formats')
@@ -70,9 +70,9 @@ class FormatPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testShowAsDisabled()
+    public function testShowAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $format = Format::query()->first();
         $this->withHeader('Authorization', "Bearer $token")
@@ -119,9 +119,9 @@ class FormatPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testStoreAsDisabled()
+    public function testStoreAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->post("/api/v1/formats")
@@ -175,9 +175,9 @@ class FormatPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testUpdateAsDisabled()
+    public function testUpdateAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $format = Format::query()->first();
         $this->withHeader('Authorization', "Bearer $token")
@@ -246,9 +246,9 @@ class FormatPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testPartialUpdateAsDisabled()
+    public function testPartialUpdateAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $format = Format::query()->first();
         $this->withHeader('Authorization', "Bearer $token")
@@ -307,9 +307,9 @@ class FormatPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testDeleteAsDisabled()
+    public function testDeleteAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $format = Format::query()->first();
         $this->withHeader('Authorization', "Bearer $token")

--- a/src/tests/Feature/Admin/MeetingPermissionsTest.php
+++ b/src/tests/Feature/Admin/MeetingPermissionsTest.php
@@ -24,9 +24,9 @@ class MeetingPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testIndexAsDisabled()
+    public function testIndexAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->get('/api/v1/meetings')
@@ -101,9 +101,9 @@ class MeetingPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testShowAsDisabled()
+    public function testShowAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $area1 = $this->createArea('area1', 'area1', 0);
         $meeting1 = $this->createMeeting(['service_body_bigint' => $area1->id_bigint]);
@@ -165,9 +165,9 @@ class MeetingPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testStoreAsDisabled()
+    public function testStoreAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->post("/api/v1/meetings")
@@ -257,9 +257,9 @@ class MeetingPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testUpdateAsDisabled()
+    public function testUpdateAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $area1 = $this->createArea('area1', 'area1', 0, adminUserId: $user->id_bigint);
         $meeting1 = $this->createMeeting(['service_body_bigint' => $area1->id_bigint]);
@@ -335,9 +335,9 @@ class MeetingPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testPartialUpdateAsDisabled()
+    public function testPartialUpdateAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $area1 = $this->createArea('area1', 'area1', 0);
         $meeting1 = $this->createMeeting(['service_body_bigint' => $area1->id_bigint]);
@@ -413,9 +413,9 @@ class MeetingPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testDeleteAsDisabled()
+    public function testDeleteAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $area1 = $this->createArea('area1', 'area1', 0, adminUserId: $user->id_bigint);
         $meeting1 = $this->createMeeting(['service_body_bigint' => $area1->id_bigint]);

--- a/src/tests/Feature/Admin/ServiceBodyPermissionsTest.php
+++ b/src/tests/Feature/Admin/ServiceBodyPermissionsTest.php
@@ -24,9 +24,9 @@ class ServiceBodyPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testIndexAsDisabled()
+    public function testIndexAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->get('/api/v1/servicebodies')
@@ -79,9 +79,9 @@ class ServiceBodyPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testShowAsDisabled()
+    public function testShowAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $area1 = $this->createArea('area1', 'area1', 0, adminUserId: $user->id_bigint);
         $this->withHeader('Authorization', "Bearer $token")
@@ -128,9 +128,9 @@ class ServiceBodyPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testStoreAsDisabled()
+    public function testStoreAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->post("/api/v1/servicebodies")
@@ -184,9 +184,9 @@ class ServiceBodyPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testUpdateAsDisabled()
+    public function testUpdateAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $area1 = $this->createArea('area1', 'area1', 0, adminUserId: $user->id_bigint);
         $this->withHeader('Authorization', "Bearer $token")
@@ -265,9 +265,9 @@ class ServiceBodyPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testPartialUpdateAsDisabled()
+    public function testPartialUpdateAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $area1 = $this->createArea('area1', 'area1', 0, adminUserId: $user->id_bigint);
         $this->withHeader('Authorization', "Bearer $token")
@@ -346,9 +346,9 @@ class ServiceBodyPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testDeleteAsDisabled()
+    public function testDeleteAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $area1 = $this->createArea('area1', 'area1', 0, adminUserId: $user->id_bigint);
         $this->withHeader('Authorization', "Bearer $token")

--- a/src/tests/Feature/Admin/TestCase.php
+++ b/src/tests/Feature/Admin/TestCase.php
@@ -112,14 +112,14 @@ class TestCase extends BaseTestCase
         ]);
     }
 
-    protected function createDisabledUser(): User
+    protected function createDeactivatedUser(): User
     {
         return User::create([
-            'user_level_tinyint' => USER::USER_LEVEL_DISABLED,
-            'name_string' => 'disabled',
+            'user_level_tinyint' => USER::USER_LEVEL_DEACTIVATED,
+            'name_string' => 'deactivated',
             'description_string' => '',
             'email_address_string' => '',
-            'login_string' => 'disabled',
+            'login_string' => 'deactivated',
             'password_string' => password_hash($this->userPassword, PASSWORD_BCRYPT),
         ]);
     }

--- a/src/tests/Feature/Admin/UserPermissionsTest.php
+++ b/src/tests/Feature/Admin/UserPermissionsTest.php
@@ -17,9 +17,9 @@ class UserPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testIndexAsDisabled()
+    public function testIndexAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->get('/api/v1/users')
@@ -45,7 +45,7 @@ class UserPermissionsTest extends TestCase
         $user2 = $this->createServiceBodyObserverUser();
         $user2->owner_id_bigint = $user->id_bigint;
         $user2->save();
-        $user3 = $this->createDisabledUser();
+        $user3 = $this->createDeactivatedUser();
 
         $this->withHeader('Authorization', "Bearer $token")
             ->get('/api/v1/users')
@@ -60,7 +60,7 @@ class UserPermissionsTest extends TestCase
         $user = $this->createAdminUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->createServiceBodyObserverUser();
-        $this->createDisabledUser();
+        $this->createDeactivatedUser();
         $this->withHeader('Authorization', "Bearer $token")
             ->get('/api/v1/users')
             ->assertStatus(200)
@@ -76,9 +76,9 @@ class UserPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testShowAsDisabled()
+    public function testShowAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->get("/api/v1/users/$user->id_bigint")
@@ -166,9 +166,9 @@ class UserPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testStoreAsDisabled()
+    public function testStoreAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->post("/api/v1/users")
@@ -212,9 +212,9 @@ class UserPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testUpdateAsDisabled()
+    public function testUpdateAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->put("/api/v1/users/$user->id_bigint")
@@ -293,9 +293,9 @@ class UserPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testPartialUpdateAsDisabled()
+    public function testPartialUpdateAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->patch("/api/v1/users/$user->id_bigint")
@@ -375,9 +375,9 @@ class UserPermissionsTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testDeleteAsDisabled()
+    public function testDeleteAsDeactivated()
     {
-        $user = $this->createDisabledUser();
+        $user = $this->createDeactivatedUser();
         $token = $user->createToken('test')->plainTextToken;
         $this->withHeader('Authorization', "Bearer $token")
             ->delete("/api/v1/users/$user->id_bigint")


### PR DESCRIPTION
We talked about this on slack -- it seems like a good idea, since otherwise "disabled user" sounds like a blind user or similar.  Some of the translations already used the equivalent of "deactivated user", for example "Deaktivierter Benutzer" in German. Others used the "blind user" meaning (as far as I could tell using Google Translate), and I fixed those as well as I could, leaving a TODO note for a native speaker to check them. There were also some incorrect translations, for example French, which used to say "deactivate user" rather than "deactivated user" (i.e., with a verb rather than an adjective).