### PR TITLE
add aggregator mode enabled to GetServerInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.5 (TBD)
 * Change name `Disabled User` to `Deactivated User`.
+* Add `aggregator_mode_enabled` to `GetServerInfo` endpoint.
 
 ## 3.0.4 (March 20, 2023)
 * The `services` and `formats` filter parameters for the `GetSearchResults` API and the `formats` filter parameter for the `GetFormats` API now accept a comma separated string (e.g. `formats=1,-12,42`) in addition to the standard array syntax.

--- a/src/app/Http/Controllers/Query/SwitcherController.php
+++ b/src/app/Http/Controllers/Query/SwitcherController.php
@@ -545,7 +545,8 @@ class SwitcherController extends Controller
             'phpVersion' => phpversion(),
             'auto_geocoding_enabled' => legacy_config('auto_geocoding_enabled'),
             'commit' => config('app.commit'),
-            'default_closed_status' => legacy_config('default_closed_status')
+            'default_closed_status' => legacy_config('default_closed_status'),
+            'aggregator_mode_enabled' => legacy_config('aggregator_mode_enabled')
         ]]);
     }
 

--- a/src/tests/Feature/GetServerInfoTest.php
+++ b/src/tests/Feature/GetServerInfoTest.php
@@ -251,4 +251,30 @@ class GetServerInfoTest extends TestCase
             ->assertStatus(200)
             ->assertJsonFragment(['commit' => config('app.commit')]);
     }
+
+    public function testDefaultClosedStatusEnabled()
+    {
+        LegacyConfig::set('default_closed_status', true);
+        $this->get('/client_interface/json/?switcher=GetServerInfo')
+            ->assertStatus(200)
+            ->assertJsonFragment(['default_closed_status' => true]);
+
+        LegacyConfig::set('default_closed_status', false);
+        $this->get('/client_interface/json/?switcher=GetServerInfo')
+            ->assertStatus(200)
+            ->assertJsonFragment(['default_closed_status' => false]);
+    }
+
+    public function testAggregatorModeEnabled()
+    {
+        LegacyConfig::set('aggregator_mode_enabled', true);
+        $this->get('/client_interface/json/?switcher=GetServerInfo')
+            ->assertStatus(200)
+            ->assertJsonFragment(['aggregator_mode_enabled' => true]);
+
+        LegacyConfig::set('aggregator_mode_enabled', false);
+        $this->get('/client_interface/json/?switcher=GetServerInfo')
+            ->assertStatus(200)
+            ->assertJsonFragment(['aggregator_mode_enabled' => false]);
+    }
 }


### PR DESCRIPTION
the old aggregator had a server version of `5.0.0` which made it easy to know if a server was an aggregator or not. Now that the codebase is joined id like to add a way to tell whats an aggregator while still knowing the actual server version.