### PR TITLE
import virtual meeting fields and time zone; allow address and city to be blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.6 (UNRELEASED)
 * The `weekdays` filter parameter for the `GetSearchResults` API now accept a comma separated string (e.g. `weekdays=1,-2`) in addition to the standard array syntax.
 * Added unit tests for login in the new UI. (These are also intended to be prototypes for other UI unit tests.)
+* Updated the NAWS import functionality for use by NAWS when importing virtual meetings, by importing the virtual meeting fields and time zone, and allowing the address and city to be blank.
 
 ## 3.0.5 (June 3, 2023)
 * Change name `Disabled User` to `Deactivated User`.

--- a/src/legacy/local_server/server_admin/NAWSImport.php
+++ b/src/legacy/local_server/server_admin/NAWSImport.php
@@ -15,7 +15,8 @@ class NAWSImport
     private $expectedColumns = array(
         'delete', 'parentname', 'committee', 'committeename', 'arearegion', 'day', 'time', 'place',
         'address', 'city', 'locborough', 'state', 'zip', 'country', 'directions', 'closed', 'wheelchr',
-        'format1', 'format2', 'format3', 'format4', 'format5', 'longitude', 'latitude', 'room'
+        'format1', 'format2', 'format3', 'format4', 'format5', 'longitude', 'latitude', 'room',
+        'phonemeetingnumber', 'virtualmeetinglink', 'virtualmeetinginfo', 'timezone'
     );
     private $server = null;
     private $areas = array();
@@ -190,7 +191,8 @@ class NAWSImport
         $ajaxHandler = new c_comdef_admin_ajax_handler(null);
         $nawsDays = array(null, 'sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday');
         // State is not a required column, because it is not always filled out for foreign countries
-        $requiredColumns = array('committeename', 'arearegion', 'day', 'time', 'address', 'city');
+        // to allow importing virtual meetings, also drop address and city as required columns
+        $requiredColumns = array('committeename', 'arearegion', 'day', 'time');
         for ($i = 1; $i <= count($this->nawsExportRows); $i++) {
             $row = $this->nawsExportRows[$i];
             if ($i == 1) {
@@ -301,6 +303,18 @@ class NAWSImport
                         break;
                     case 'latitude':
                         $meetingData['latitude'] = $value;
+                        break;
+                    case 'phonemeetingnumber':
+                        $meetingData['phone_meeting_number'] = $value;
+                        break;
+                    case 'virtualmeetinglink':
+                        $meetingData['virtual_meeting_link'] = $value;
+                        break;
+                    case 'virtualmeetinginfo':
+                        $meetingData['virtual_meeting_additional_info'] = $value;
+                        break;
+                    case 'timezone':
+                        $meetingData['time_zone'] = $value;
                         break;
                     case 'unpublished':
                         if ($value == '1') {


### PR DESCRIPTION
These are some minor updates to the NAWS import functionality so that NAWS could import their virtual meeting information.  I made these changes to a custom version of the root server for them, but it seems better to have these in the main branch.