### PR TITLE
prevent data fix migration from running on aggregator

### DIFF
--- a/src/database/migrations/2024_06_12_164303_fix_meeting_lang_enum.php
+++ b/src/database/migrations/2024_06_12_164303_fix_meeting_lang_enum.php
@@ -12,9 +12,11 @@ return new class extends Migration
      */
     public function up()
     {
-        DB::table('comdef_meetings_main')
-            ->whereNull('lang_enum')
-            ->update(['lang_enum' => config('app.locale')]);
+        if (!legacy_config('aggregator_mode_enabled')) {
+            DB::table('comdef_meetings_main')
+                ->whereNull('lang_enum')
+                ->update(['lang_enum' => config('app.locale')]);
+        }
     }
 
     /**


### PR DESCRIPTION
This shouldn't run against aggregator, because its data will get fixed when folks upgrade their root servers.