### PR TITLE
make both -rc and -beta tag suffixes create a prerelease

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
           curl -LO https://raw.githubusercontent.com/bmlt-enabled/release-notes-tool/master/gh-release-notes.sh
           chmod +x gh-release-notes.sh
           ./gh-release-notes.sh CHANGELOG.md "##"
-          RELEASE_TYPE=$(if [[ "$GITHUB_REF_NAME" =~ "beta" ]]; then echo "true"; else echo "false"; fi)
+          RELEASE_TYPE=$(if [[ "$GITHUB_REF_NAME" =~ -(beta|rc) ]]; then echo "true"; else echo "false"; fi)
           echo "RELEASE_TYPE=${RELEASE_TYPE}" >> $GITHUB_ENV
 
       - name: Create Release 🎉


### PR DESCRIPTION
```
[~/git/bmlt-enabled/bmlt-root-server]$ [[ "3.1.0" =~ -(beta|rc) ]]
[~/git/bmlt-enabled/bmlt-root-server]$ echo $?
1
[~/git/bmlt-enabled/bmlt-root-server]$ [[ "3.1.0-beta" =~ -(beta|rc) ]]
[~/git/bmlt-enabled/bmlt-root-server]$ echo $?
0
[~/git/bmlt-enabled/bmlt-root-server]$ [[ "3.1.0-rc" =~ -(beta|rc) ]]
[~/git/bmlt-enabled/bmlt-root-server]$ echo $?
0
[~/git/bmlt-enabled/bmlt-root-server]$ [[ "3.1.0-blah" =~ -(beta|rc) ]]
[~/git/bmlt-enabled/bmlt-root-server]$ echo $?
1
```
