### PR TITLE
always persist -1 when setting ownerId to a server admin

### DIFF
--- a/src/app/Http/Middleware/DatabaseMigrations.php
+++ b/src/app/Http/Middleware/DatabaseMigrations.php
@@ -52,7 +52,7 @@ class DatabaseMigrations
             return true;
         }
 
-        if (!$this->migrationRepository->migrationExists('2024_06_12_164303_fix_meeting_lang_enum')) {
+        if (!$this->migrationRepository->migrationExists('2024_07_20_203802_fix_admin_user_owners')) {
             return true;
         }
 

--- a/src/app/Interfaces/UserRepositoryInterface.php
+++ b/src/app/Interfaces/UserRepositoryInterface.php
@@ -6,6 +6,7 @@ use App\Models\User;
 
 interface UserRepositoryInterface
 {
+    public function getById(int $id);
     public function getByUsername(string $username);
     public function search(array $includeIds = null, array $includeOwnerIds = null);
     public function create(array $values): User;

--- a/src/app/Repositories/UserRepository.php
+++ b/src/app/Repositories/UserRepository.php
@@ -11,6 +11,11 @@ use Illuminate\Support\Facades\Hash;
 
 class UserRepository implements UserRepositoryInterface
 {
+    public function getById(int $id)
+    {
+        return User::query()->where('id_bigint', $id)->first();
+    }
+
     public function getByUsername(string $username)
     {
         return User::query()->where('login_string', $username)->first();

--- a/src/database/migrations/2024_07_20_203802_fix_admin_user_owners.php
+++ b/src/database/migrations/2024_07_20_203802_fix_admin_user_owners.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!legacy_config('aggregator_mode_enabled')) {
+            $adminUserIds = DB::table('comdef_users')->where('user_level_tinyint', 1)->pluck('id_bigint');
+            DB::table('comdef_users')->whereIn('owner_id_bigint', $adminUserIds)->update(['owner_id_bigint' => -1]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+    }
+};

--- a/src/tests/Feature/Admin/UserChangeTest.php
+++ b/src/tests/Feature/Admin/UserChangeTest.php
@@ -46,8 +46,9 @@ class UserChangeTest extends TestCase
 
     public function testChangedUserChange()
     {
-        $user = $this->createAdminUser();
-        $token = $user->createToken('test')->plainTextToken;
+        $admin = $this->createAdminUser();
+        $token = $admin->createToken('test')->plainTextToken;
+        $user = $this->createServiceBodyAdminUser();
         $data = [
             'username' => 'test',
             'password' => 'this is a valid password',
@@ -64,7 +65,7 @@ class UserChangeTest extends TestCase
             ->assertStatus(204);
 
         $change = Change::query()->first();
-        $this->assertEquals($user->id_bigint, $change->user_id_bigint);
+        $this->assertEquals($admin->id_bigint, $change->user_id_bigint);
         $this->assertEquals($user->id_bigint, $change->service_body_id_bigint);
         $this->assertEquals(App::currentLocale(), $change->lang_enum);
         $this->assertEquals('c_comdef_user', $change->object_class_string);

--- a/src/tests/Feature/Admin/UserCreateTest.php
+++ b/src/tests/Feature/Admin/UserCreateTest.php
@@ -47,7 +47,25 @@ class UserCreateTest extends TestCase
         $this->assertEquals(-1, $user->owner_id_bigint);
     }
 
-    public function testCreateSuccessWithOwner()
+    public function testCreateSuccessWithServerAdminOwner()
+    {
+        $user = $this->createAdminUser();
+        $token = $user->createToken('test')->plainTextToken;
+        $data = $this->validPayload();
+        $data['ownerId'] = $user->id_bigint;
+
+        $this->withHeader('Authorization', "Bearer $token")
+            ->post('/api/v1/users', $data)
+            ->assertStatus(201)
+            ->assertJsonFragment(['username' => $data['username']])
+            ->assertJsonFragment(['type' => $data['type']])
+            ->assertJsonFragment(['displayName' => $data['displayName']])
+            ->assertJsonFragment(['description' => $data['description']])
+            ->assertJsonFragment(['email' => $data['email']])
+            ->assertJsonFragment(['ownerId' => null]);
+    }
+
+    public function testCreateSuccessWithServiceBodyAdminOwner()
     {
         $user = $this->createAdminUser();
         $token = $user->createToken('test')->plainTextToken;

--- a/src/tests/Feature/Admin/UserPartialUpdateTest.php
+++ b/src/tests/Feature/Admin/UserPartialUpdateTest.php
@@ -16,63 +16,73 @@ class UserPartialUpdateTest extends TestCase
         $user1 = $this->createAdminUser();
         $token = $user1->createToken('test')->plainTextToken;
         $user2 = $this->createServiceBodyAdminUser();
+        $user3 = $this->createServiceBodyObserverUser();
 
         $data = ['username' => 'new username'];
         $this->withHeader('Authorization', "Bearer $token")
-            ->patch("/api/v1/users/$user2->id_bigint", $data)
+            ->patch("/api/v1/users/$user3->id_bigint", $data)
             ->assertStatus(204);
-        $user2->refresh();
-        $this->assertEquals($data['username'], $user2->login_string);
+        $user3->refresh();
+        $this->assertEquals($data['username'], $user3->login_string);
 
         $data = ['password' => 'this is a valid password'];
         $this->withHeader('Authorization', "Bearer $token")
-            ->patch("/api/v1/users/$user2->id_bigint", $data)
+            ->patch("/api/v1/users/$user3->id_bigint", $data)
             ->assertStatus(204);
-        $oldPasswordHash = $user2->password_string;
-        $user2->refresh();
-        $this->assertNotEquals($oldPasswordHash, $user2->password_string);
+        $oldPasswordHash = $user3->password_string;
+        $user3->refresh();
+        $this->assertNotEquals($oldPasswordHash, $user3->password_string);
 
         $data = ['type' => User::USER_TYPE_ADMIN];
         $this->withHeader('Authorization', "Bearer $token")
-            ->patch("/api/v1/users/$user2->id_bigint", $data)
+            ->patch("/api/v1/users/$user3->id_bigint", $data)
             ->assertStatus(204);
-        $user2->refresh();
-        $this->assertEquals(User::USER_TYPE_TO_USER_LEVEL_MAP[$data['type']], $user2->user_level_tinyint);
+        $user3->refresh();
+        $this->assertEquals(User::USER_TYPE_TO_USER_LEVEL_MAP[$data['type']], $user3->user_level_tinyint);
 
         $data = ['displayName' => 'pretty name'];
         $this->withHeader('Authorization', "Bearer $token")
-            ->patch("/api/v1/users/$user2->id_bigint", $data)
+            ->patch("/api/v1/users/$user3->id_bigint", $data)
             ->assertStatus(204);
-        $user2->refresh();
-        $this->assertEquals($data['displayName'], $user2->name_string);
+        $user3->refresh();
+        $this->assertEquals($data['displayName'], $user3->name_string);
 
         $data = ['description' => 'pretty new description'];
         $this->withHeader('Authorization', "Bearer $token")
-            ->patch("/api/v1/users/$user2->id_bigint", $data)
+            ->patch("/api/v1/users/$user3->id_bigint", $data)
             ->assertStatus(204);
-        $user2->refresh();
-        $this->assertEquals($data['description'], $user2->description_string);
+        $user3->refresh();
+        $this->assertEquals($data['description'], $user3->description_string);
 
         $data = ['email' => 'new@email.com'];
         $this->withHeader('Authorization', "Bearer $token")
-            ->patch("/api/v1/users/$user2->id_bigint", $data)
+            ->patch("/api/v1/users/$user3->id_bigint", $data)
             ->assertStatus(204);
-        $user2->refresh();
-        $this->assertEquals($data['email'], $user2->email_address_string);
+        $user3->refresh();
+        $this->assertEquals($data['email'], $user3->email_address_string);
 
+        // ownerId to server admin
         $data = ['ownerId' => $user1->id_bigint];
         $this->withHeader('Authorization', "Bearer $token")
-            ->patch("/api/v1/users/$user2->id_bigint", $data)
+            ->patch("/api/v1/users/$user3->id_bigint", $data)
             ->assertStatus(204);
-        $user2->refresh();
-        $this->assertEquals($data['ownerId'], $user2->owner_id_bigint);
+        $user3->refresh();
+        $this->assertEquals(-1, $user3->owner_id_bigint);
+
+        // ownerId to service body admin
+        $data = ['ownerId' => $user2->id_bigint];
+        $this->withHeader('Authorization', "Bearer $token")
+            ->patch("/api/v1/users/$user3->id_bigint", $data)
+            ->assertStatus(204);
+        $user3->refresh();
+        $this->assertEquals($data['ownerId'], $user3->owner_id_bigint);
 
         $data = ['ownerId' => null];
         $this->withHeader('Authorization', "Bearer $token")
-            ->patch("/api/v1/users/$user2->id_bigint", $data)
+            ->patch("/api/v1/users/$user3->id_bigint", $data)
             ->assertStatus(204);
-        $user2->refresh();
-        $this->assertEquals(-1, $user2->owner_id_bigint);
+        $user3->refresh();
+        $this->assertEquals(-1, $user3->owner_id_bigint);
     }
 
     public function testPartialUpdateUserAsServiceBodyAdmin()


### PR DESCRIPTION
Setting a user's owner to an admin is really the same as having no owner, so we should be consistent and always set `owner_id_bigint` to `-1` when someone sets a user's owner to an admin.