### PR TITLE
consider assigned service bodies when deleting a user

### DIFF
--- a/src/app/Http/Controllers/Admin/Swagger/UserController.php
+++ b/src/app/Http/Controllers/Admin/Swagger/UserController.php
@@ -163,8 +163,8 @@ class UserController extends Controller
      *     @OA\Response(response=404, description="Returns when no user exists.",
      *         @OA\JsonContent(ref="#/components/schemas/NotFoundError")
      *     ),
-     *     @OA\Response(response=422, description="Validation error.",
-     *         @OA\JsonContent(ref="#/components/schemas/ValidationError")
+     *     @OA\Response(response=409, description="Returns when user is still referenced by service bodies.",
+     *         @OA\JsonContent(ref="#/components/schemas/ConflictError")
      *     ),
      * )
      */

--- a/src/app/Http/Controllers/Admin/UserController.php
+++ b/src/app/Http/Controllers/Admin/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Resources\Admin\UserResource;
+use App\Http\Responses\JsonResponse;
 use App\Interfaces\UserRepositoryInterface;
 use App\Models\User;
 use Illuminate\Http\Request;
@@ -117,6 +118,11 @@ class UserController extends ResourceController
 
     public function destroy(User $user)
     {
+        if ($user->serviceBodies()->exists()) {
+            return new JsonResponse([
+                'message' => 'You cannot delete a user while service bodies are assigned to it.'
+            ], 409);
+        }
         $this->userRepository->delete($user->id_bigint);
         return response()->noContent();
     }

--- a/src/app/Interfaces/ServiceBodyRepositoryInterface.php
+++ b/src/app/Interfaces/ServiceBodyRepositoryInterface.php
@@ -22,5 +22,6 @@ interface ServiceBodyRepositoryInterface
     public function getAdminServiceBodyIds(int $userId): Collection;
     public function getChildren(array $parents): array;
     public function getParents(array $children): array;
+    public function removeUser(int $userId);
     public function import(int $rootServerId, Collection $externalObjects): void;
 }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -74,4 +74,9 @@ class User extends Model implements AuthenticatableContract
     {
         return $this->hasMany(self::class, 'owner_id_bigint');
     }
+
+    public function serviceBodies()
+    {
+        return $this->hasMany(ServiceBody::class, 'principal_user_bigint');
+    }
 }

--- a/src/app/Repositories/ServiceBodyRepository.php
+++ b/src/app/Repositories/ServiceBodyRepository.php
@@ -220,6 +220,21 @@ class ServiceBodyRepository implements ServiceBodyRepositoryInterface
         return $ret;
     }
 
+    public function removeUser(int $userId)
+    {
+        $serviceBodyIds = $this->getAssignedServiceBodyIds($userId)->toArray();
+        foreach ($this->search($serviceBodyIds) as $serviceBody) {
+            $editorIds = empty($serviceBody->editors_string) ? [] : array_map(fn ($v) => intval($v), explode(',', $serviceBody->editors_string));
+            $values = [
+                'editors_string' => collect($editorIds)
+                    ->filter(fn ($v) => $v != $userId)
+                    ->map(fn ($v) => strval($v))
+                    ->join(',')
+            ];
+            $this->update($serviceBody->id_bigint, $values);
+        }
+    }
+
     public function import(int $rootServerId, Collection $externalObjects): void
     {
         $rootServer = RootServer::query()->where('id', $rootServerId)->firstOrFail();

--- a/src/storage/api-docs/api-docs.json
+++ b/src/storage/api-docs/api-docs.json
@@ -1859,12 +1859,12 @@
                             }
                         }
                     },
-                    "422": {
-                        "description": "Validation error.",
+                    "409": {
+                        "description": "Returns when user is still referenced by service bodies.",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ValidationError"
+                                    "$ref": "#/components/schemas/ConflictError"
                                 }
                             }
                         }

--- a/src/tests/Feature/Admin/UserDeleteTest.php
+++ b/src/tests/Feature/Admin/UserDeleteTest.php
@@ -23,6 +23,42 @@ class UserDeleteTest extends TestCase
         $this->assertFalse(User::query()->where('id_bigint', $user2->id_bigint)->exists());
     }
 
+    public function testDeleteUserHasServiceBodies()
+    {
+        $user = $this->createAdminUser();
+        $token = $user->createToken('test')->plainTextToken;
+        $user2 = $this->createServiceBodyAdminUser();
+        $this->createArea('area1', 'area1', 0, adminUserId: $user2->id_bigint);
+
+        $this->withHeader('Authorization', "Bearer $token")
+            ->delete("/api/v1/users/$user2->id_bigint")
+            ->assertStatus(409);
+
+        $this->assertTrue(User::query()->where('id_bigint', $user2->id_bigint)->exists());
+    }
+
+    public function testDeleteUserAssignedServiceBodies()
+    {
+        $user = $this->createAdminUser();
+        $token = $user->createToken('test')->plainTextToken;
+        $user2 = $this->createServiceBodyAdminUser();
+        $area1 = $this->createArea('area1', 'area1', 0, adminUserId: $user->id_bigint, assignedUserIds: [$user->id_bigint, $user2->id_bigint]);
+        $area2 = $this->createArea('area2', 'area2', 0, adminUserId: $user->id_bigint, assignedUserIds: [$user2->id_bigint]);
+
+        $this->withHeader('Authorization', "Bearer $token")
+            ->delete("/api/v1/users/$user2->id_bigint")
+            ->assertStatus(204);
+
+        $this->assertFalse(User::query()->where('id_bigint', $user2->id_bigint)->exists());
+
+        $area1->refresh();
+        $this->assertEquals(strval($user->id_bigint), $area1->editors_string);
+
+        $area2->refresh();
+        $this->assertEquals($user->id_bigint, $area2->principal_user_bigint);
+        $this->assertEquals('', $area2->editors_string);
+    }
+
     public function testDeleteUserReassignsOrphans()
     {
         $user = $this->createAdminUser();


### PR DESCRIPTION
When you try to delete a user that is assigned as admin to a service body, you'll get a 409 response and the user will not be deleted.

When you delete a user that is assigned to service bodies as an editor, that user's id will be removed from those service bodies upon deletion.