### PR TITLE
Added TypeScript declaration, Modified  to return optional language or all languages

### DIFF
--- a/src/resources/js/globals.d.ts
+++ b/src/resources/js/globals.d.ts
@@ -5,3 +5,9 @@ declare const settings: {
   languageMapping: Record<string, string>;
   version: string;
 };
+
+declare module 'localized-strings' {
+  export interface LocalizedStringsMethods {
+    getContent(): any;
+  }
+}

--- a/src/resources/js/stores/localization.ts
+++ b/src/resources/js/stores/localization.ts
@@ -291,9 +291,12 @@ class Translations {
     this.store.set(strings);
   }
 
-  getTranslationsForLanguage(language: string | null): Record<string, string> {
-    // @ts-expect-error library missing type def for getContent() and we trust this lib is prob never changing
-    return strings._props[language ?? this.getLanguage()] || {};
+  getTranslationsForLanguage(language: string | null = null): Record<string, string> {
+    return strings.getContent()[language ?? this.getLanguage()];
+  }
+
+  getTranslationsForAllLanguages(): Record<string, Record<string, string>> {
+    return strings.getContent();
   }
 }
 


### PR DESCRIPTION
### Changes
- Added TypeScript declaration for the `localized-strings` module to include the `getContent` method.
- Modified `getTranslationsForLanguage` to accept an optional language parameter and return the appropriate type.

### Benefits
- Facilitates testing of all languages by returning an object with all translations by default.
- Will allow us in the future to export a translations file easily.
- Allows for fetching translations for a specific language if specified.


The correct type was added in [localized-strings](https://github.com/stefalda/localized-strings/blob/master/lib/LocalizedStrings.d.ts#L61), but it is only in the master branch and missed being released in version 0.2.4, which was released 5 years ago. Given the lack of recent activity, I don't anticipate any new releases. As a precaution, I forked the repository.