### PR TITLE
fix and move service body modal test

### DIFF
--- a/src/resources/js/tests/Login.spec.ts
+++ b/src/resources/js/tests/Login.spec.ts
@@ -123,10 +123,7 @@ describe('navbar tests', () => {
     expect(await screen.findByRole('heading', { level: 2, name: 'Formats' })).toBeInTheDocument();
     replace('/');
     await user.click(await screen.findByRole('link', { name: 'Service Bodies', hidden: true }));
-    // TODO: the following test results in an error message:
-    //     TODO show error dialog The request failed and the interceptors did not return an alternative response
-    // so commented out for now
-    // expect(await screen.findByRole('heading', { level: 2, name: 'Service Bodies',  })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { level: 2, name: 'Service Bodies' })).toBeInTheDocument();
     replace('/');
     await user.click(await screen.findByRole('link', { name: 'Users', hidden: true }));
     expect(await screen.findByRole('heading', { level: 2, name: 'Users' })).toBeInTheDocument();

--- a/src/resources/js/tests/ServiceBodies.spec.ts
+++ b/src/resources/js/tests/ServiceBodies.spec.ts
@@ -30,3 +30,15 @@ describe('check content in Service Body tab when logged in as various users', ()
     expect(screen.getByRole('cell', { name: 'Mountain Area' })).toBeInTheDocument();
   });
 });
+
+describe('check editing, adding, and deleting service bodies using the popup dialog boxes', () => {
+  test('test Confirm modal appears when attempting to close with unsaved changes', async () => {
+    const user = await login('serveradmin', 'Service Bodies');
+    await user.click(await screen.findByRole('cell', { name: 'Rural Area' }));
+    const helpline = screen.getByRole('textbox', { name: 'Helpline' }) as HTMLInputElement;
+    await user.clear(helpline);
+    await user.type(helpline, '555-867-5309');
+    await user.click(await screen.findByRole('button', { name: 'Close modal' }));
+    expect(screen.getByText('You have unsaved changes. Do you really want to close?')).toBeInTheDocument();
+  });
+});

--- a/src/resources/js/tests/ServiceBodies.spec.ts
+++ b/src/resources/js/tests/ServiceBodies.spec.ts
@@ -1,7 +1,8 @@
 import { beforeAll, beforeEach, describe, test } from 'vitest';
 import { screen } from '@testing-library/svelte';
 import '@testing-library/jest-dom';
-import { login, sharedAfterEach, sharedBeforeAll, sharedBeforeEach } from './sharedDataAndMocks';
+import { login, mockDeletedServiceBodyId, mockSavedServiceBodyCreate, mockSavedServiceBodyUpdate, sharedAfterEach, sharedBeforeAll, sharedBeforeEach } from './sharedDataAndMocks';
+import userEvent from '@testing-library/user-event';
 
 beforeAll(sharedBeforeAll);
 beforeEach(sharedBeforeEach);
@@ -32,6 +33,84 @@ describe('check content in Service Body tab when logged in as various users', ()
 });
 
 describe('check editing, adding, and deleting service bodies using the popup dialog boxes', () => {
+  test('logged in as serveradmin; edit Rural Area Service Body', async () => {
+    // For each field displayed in the popup, check the default contents, edit the field, and check the result.
+    // Then save the edits, and check the contents of the User Update request.
+    const user = await login('serveradmin', 'Service Bodies');
+    await user.click(await screen.findByRole('cell', { name: 'Rural Area' }));
+    // The applyChanges button should be disabled at this point since there haven't been any edits.
+    // We'll need to find the Apply Changes button again later, after there have been changes -- for some reason it's
+    // a different button after it's enabled.
+    const b = screen.getByRole('button', { name: 'Apply Changes' });
+    expect(b).toBeDisabled();
+    expect(b.attributes.getNamedItem('class')?.value.includes('cursor-not-allowed')).toBeTruthy();
+    const name = screen.getByRole('textbox', { name: 'Name' }) as HTMLInputElement;
+    expect(name.value).toBe('Rural Area');
+    await user.clear(name);
+    await user.type(name, 'More Rural Area');
+    expect(name.value).toBe('More Rural Area');
+    const serviceBodyAdmin = screen.getByRole('combobox', { name: 'Admin' }) as HTMLSelectElement;
+    expect(serviceBodyAdmin.value).toBe('7'); // id of Rural Area Service Body
+    await userEvent.selectOptions(serviceBodyAdmin, ['Mountain Area']);
+    expect(serviceBodyAdmin.value).toBe('6'); // id of Mountain Area User
+    const serviceBodiesType = screen.getByRole('combobox', { name: 'Service Body Type' }) as HTMLSelectElement;
+    expect(serviceBodiesType.value).toBe('AS');
+    await userEvent.selectOptions(serviceBodiesType, ['RS']);
+    expect(serviceBodiesType.value).toBe('RS');
+    const serviceBodyParent = screen.getByRole('combobox', { name: 'Service Body Parent' }) as HTMLSelectElement;
+    expect(serviceBodyParent.value).toBe('2'); // id of Big Region
+    await userEvent.selectOptions(serviceBodyParent, ['1']);
+    expect(serviceBodyParent.value).toBe('1');
+    const meetingListEditors = screen.getByLabelText('Meeting List Editors') as HTMLSelectElement;
+    const initialSelectedOptions = Array.from(meetingListEditors.selectedOptions).map((option) => option.value);
+    expect(initialSelectedOptions).toEqual(['2', '7']);
+    await userEvent.selectOptions(meetingListEditors, ['2', '6']);
+    const selectedOptions = Array.from(meetingListEditors.selectedOptions).map((option) => option.value);
+    expect(selectedOptions).toEqual(['6', '2', '7']);
+    const email = screen.getByRole('textbox', { name: 'Email' }) as HTMLInputElement;
+    expect(email.value).toBe('rural@bmlt.app');
+    await user.clear(email);
+    await user.type(email, 'morerural@bmlt.app');
+    expect(email.value).toBe('morerural@bmlt.app');
+    const description = screen.getByRole('textbox', { name: 'Description' }) as HTMLInputElement;
+    expect(description.value).toBe('Rural Area Description');
+    await user.type(description, ' now more rural');
+    expect(description.value).toBe('Rural Area Description now more rural');
+    const url = screen.getByRole('textbox', { name: 'Web Site URL' }) as HTMLInputElement;
+    expect(url.value).toBe('https://ruralarea.example.com');
+    await user.clear(url);
+    await user.type(url, 'https://moreruralarea.example.com');
+    expect(url.value).toBe('https://moreruralarea.example.com');
+    const helpline = screen.getByRole('textbox', { name: 'Helpline' }) as HTMLInputElement;
+    expect(helpline.value).toBe('803-555-7247');
+    await user.clear(helpline);
+    await user.type(helpline, '843-555-7247');
+    expect(helpline.value).toBe('843-555-7247');
+    const worldid = screen.getByRole('textbox', { name: 'World Committee Code' }) as HTMLInputElement;
+    expect(worldid.value).toBe('AS778');
+    await user.clear(worldid);
+    await user.type(worldid, 'AS788');
+    expect(worldid.value).toBe('AS788');
+    const applyChanges = screen.getByRole('button', { name: 'Apply Changes' });
+    // no need to explicitly test that applyChanges is enabled, since clicking on it wouldn't work if it were disabled
+    await user.click(applyChanges);
+    // // check all the fields in the mock Service Body Update for their new values
+    expect(mockSavedServiceBodyUpdate?.name).toBe('More Rural Area');
+    expect(mockSavedServiceBodyUpdate?.adminUserId).toBe(6);
+    expect(mockSavedServiceBodyUpdate?.type).toBe('RS');
+    expect(mockSavedServiceBodyUpdate?.parentId).toBe(1);
+    expect(mockSavedServiceBodyUpdate?.assignedUserIds).toStrictEqual([6, 2, 7]);
+    expect(mockSavedServiceBodyUpdate?.email).toBe('morerural@bmlt.app');
+    expect(mockSavedServiceBodyUpdate?.description).toBe('Rural Area Description now more rural');
+    expect(mockSavedServiceBodyUpdate?.url).toBe('https://moreruralarea.example.com');
+    expect(mockSavedServiceBodyUpdate?.helpline).toBe('843-555-7247');
+    expect(mockSavedServiceBodyUpdate?.worldId).toBe('AS788');
+
+    // check that user create and user delete weren't touched
+    expect(mockSavedServiceBodyCreate).toBe(null);
+    expect(mockDeletedServiceBodyId).toBe(null);
+  });
+
   test('test Confirm modal appears when attempting to close with unsaved changes', async () => {
     const user = await login('serveradmin', 'Service Bodies');
     await user.click(await screen.findByRole('cell', { name: 'Rural Area' }));

--- a/src/resources/js/tests/ServiceBodyForm.spec.ts
+++ b/src/resources/js/tests/ServiceBodyForm.spec.ts
@@ -1,11 +1,9 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import { describe, test } from 'vitest';
 import ServiceBodyForm from '../components/ServiceBodyForm.svelte';
-import ServiceBodyModal from '../components/ServiceBodyModal.svelte';
 import { translations } from '../stores/localization';
 import type { ServiceBody, User } from 'bmlt-root-server-client';
 import { allServiceBodies, allUsers, login } from './sharedDataAndMocks';
-import userEvent from '@testing-library/user-event';
 
 const serviceBodies: ServiceBody[] = allServiceBodies;
 
@@ -89,15 +87,5 @@ describe('ServiceBodyForm Component', () => {
     render(ServiceBodyForm, { props: { selectedServiceBody, serviceBodies, users } });
     expect(screen.getByLabelText(translations.getString('nameTitle'))).toBeDisabled();
     expect(screen.getByLabelText(translations.getString('adminTitle'))).toBeDisabled();
-  });
-
-  test('test Confirm modal appears when attempting to close with unsaved changes', async () => {
-    await login('NorthernZone');
-    render(ServiceBodyModal, { props: { selectedServiceBody, serviceBodies, users, showModal: true } });
-    const user = userEvent.setup();
-    const description = (await screen.findByLabelText(translations.getString('descriptionTitle'))) as HTMLInputElement;
-    await user.type(description, 'My Description');
-    await user.click(await screen.findByRole('button', { name: 'Close modal' }));
-    expect(screen.getByText(translations.getString('youHaveUnsavedChanges'))).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
this resolves #995 and resolves #999
I think 999 must of been fixed previously. I also thought there could of been some sort of timing issue in login function but couldn't find out. the service bodies page does have to do more things on mount. 