### PR TITLE
Set proper node version for builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,10 +109,10 @@ jobs:
         run: |
           make composer
 
-      - name: setup node 16 ❇️
+      - name: setup node 20 ❇️
         uses: actions/setup-node@v4.0.2
         with:
-          node-version: 16
+          node-version: 20
 
       - name: make frontend 🐥
         run: |


### PR DESCRIPTION
This resolves these warnings https://github.com/bmlt-enabled/bmlt-root-server/actions/runs/10801827919/job/29962789103#step:6:16 and sets same node version for tests as build