### PR TITLE
Add support for config array settings using comma seperated strings

### DIFF
--- a/docker/write-config.sh
+++ b/docker/write-config.sh
@@ -55,3 +55,37 @@ if [ ! -z "$AGGREGATOR_MAX_GEO_WIDTH_KM" ]
 then
     echo "\$aggregator_max_geo_width_km = ${AGGREGATOR_MAX_GEO_WIDTH_KM};" >> /var/www/html/auto-config.inc.php
 fi
+
+if [ ! -z "$MEETING_STATES_AND_PROVINCES" ]
+then
+    IFS=',' read -r -a array <<< "$MEETING_STATES_AND_PROVINCES"
+    echo -n "\$meeting_states_and_provinces = [" >> /var/www/html/auto-config.inc.php
+    for ((i=0; i<${#array[@]}; i++))
+    do
+        if [ $i -eq $((${#array[@]}-1)) ]
+        then
+            # No trailing comma if last item
+            echo -n "\"${array[i]}\"" >> /var/www/html/auto-config.inc.php
+        else
+            echo -n "\"${array[i]}\"," >> /var/www/html/auto-config.inc.php
+        fi
+    done
+    echo "];" >> /var/www/html/auto-config.inc.php
+fi
+
+if [ ! -z "$MEETING_COUNTIES_AND_SUB_PROVINCES" ]
+then
+    IFS=',' read -r -a array <<< "$MEETING_COUNTIES_AND_SUB_PROVINCES"
+    echo -n "\$meeting_counties_and_sub_provinces = [" >> /var/www/html/auto-config.inc.php
+    for ((i=0; i<${#array[@]}; i++))
+    do
+        if [ $i -eq $((${#array[@]}-1)) ]
+        then
+            # No trailing comma if last item
+            echo -n "\"${array[i]}\"" >> /var/www/html/auto-config.inc.php
+        else
+            echo -n "\"${array[i]}\"," >> /var/www/html/auto-config.inc.php
+        fi
+    done
+    echo "];" >> /var/www/html/auto-config.inc.php
+fi

--- a/docker/write-config.sh
+++ b/docker/write-config.sh
@@ -58,34 +58,10 @@ fi
 
 if [ ! -z "$MEETING_STATES_AND_PROVINCES" ]
 then
-    IFS=',' read -r -a array <<< "$MEETING_STATES_AND_PROVINCES"
-    echo -n "\$meeting_states_and_provinces = [" >> /var/www/html/auto-config.inc.php
-    for ((i=0; i<${#array[@]}; i++))
-    do
-        if [ $i -eq $((${#array[@]}-1)) ]
-        then
-            # No trailing comma if last item
-            echo -n "\"${array[i]}\"" >> /var/www/html/auto-config.inc.php
-        else
-            echo -n "\"${array[i]}\"," >> /var/www/html/auto-config.inc.php
-        fi
-    done
-    echo "];" >> /var/www/html/auto-config.inc.php
+    echo "\$meeting_states_and_provinces = \"${MEETING_STATES_AND_PROVINCES}\";" >> /var/www/html/auto-config.inc.php
 fi
 
 if [ ! -z "$MEETING_COUNTIES_AND_SUB_PROVINCES" ]
 then
-    IFS=',' read -r -a array <<< "$MEETING_COUNTIES_AND_SUB_PROVINCES"
-    echo -n "\$meeting_counties_and_sub_provinces = [" >> /var/www/html/auto-config.inc.php
-    for ((i=0; i<${#array[@]}; i++))
-    do
-        if [ $i -eq $((${#array[@]}-1)) ]
-        then
-            # No trailing comma if last item
-            echo -n "\"${array[i]}\"" >> /var/www/html/auto-config.inc.php
-        else
-            echo -n "\"${array[i]}\"," >> /var/www/html/auto-config.inc.php
-        fi
-    done
-    echo "];" >> /var/www/html/auto-config.inc.php
+    echo "\$meeting_counties_and_sub_provinces = \"${MEETING_COUNTIES_AND_SUB_PROVINCES}\";" >> /var/www/html/auto-config.inc.php
 fi

--- a/src/app/LegacyConfig.php
+++ b/src/app/LegacyConfig.php
@@ -103,8 +103,12 @@ class LegacyConfig
         $config['enable_email_contact'] = isset($g_enable_email_contact) && $g_enable_email_contact;
         $config['include_service_body_admin_on_emails'] = isset($include_service_body_admin_on_emails) && $include_service_body_admin_on_emails;
         $config['change_depth_for_meetings'] = $change_depth_for_meetings ?? 0;
-        $config['meeting_states_and_provinces'] = $meeting_states_and_provinces ?? [];
-        $config['meeting_counties_and_sub_provinces'] = $meeting_counties_and_sub_provinces ?? [];
+        $config['meeting_states_and_provinces'] = isset($meeting_states_and_provinces) && is_string($meeting_states_and_provinces)
+            ? collect(explode(',', $meeting_states_and_provinces))->map(fn($id) => trim($id))->toArray()
+            : ($meeting_states_and_provinces ?? []);
+        $config['meeting_counties_and_sub_provinces'] = isset($meeting_counties_and_sub_provinces) && is_string($meeting_counties_and_sub_provinces)
+            ? collect(explode(',', $meeting_counties_and_sub_provinces))->map(fn($id) => trim($id))->toArray()
+            : ($meeting_counties_and_sub_provinces ?? []);
         $config['meeting_time_zones_enabled'] = isset($meeting_time_zones_enabled) && $meeting_time_zones_enabled;
         $config['search_spec_map_center_longitude'] = isset($search_spec_map_center) && is_array($search_spec_map_center) && isset($search_spec_map_center['longitude']) ? $search_spec_map_center['longitude'] : -118.563659;
         $config['search_spec_map_center_latitude'] = isset($search_spec_map_center) && is_array($search_spec_map_center) && isset($search_spec_map_center['latitude']) ? $search_spec_map_center['latitude'] : 34.235918;

--- a/src/legacy/server/c_comdef_server.class.php
+++ b/src/legacy/server/c_comdef_server.class.php
@@ -403,7 +403,7 @@ class c_comdef_server
                 );
             }
         }
-        
+
         /// Create our internal container, and give it the array.
          $this->_formatTypes_obj = new c_comdef_format_types($this, $obj_array);
     }
@@ -2802,8 +2802,12 @@ class c_comdef_server
                 c_comdef_server::$server_local_strings['zip_auto_geocoding_enabled'] = isset($zip_auto_geocoding_enabled) ? $zip_auto_geocoding_enabled : false;
                 c_comdef_server::$server_local_strings['county_auto_geocoding_enabled'] = isset($county_auto_geocoding_enabled) ? $county_auto_geocoding_enabled : false;
                 c_comdef_server::$server_local_strings['sort_formats'] = isset($sort_formats) ? $sort_formats : true;
-                c_comdef_server::$server_local_strings['meeting_counties_and_sub_provinces'] = isset($meeting_counties_and_sub_provinces) ? $meeting_counties_and_sub_provinces : array();
-                c_comdef_server::$server_local_strings['meeting_states_and_provinces'] = isset($meeting_states_and_provinces) ? $meeting_states_and_provinces : array();
+                c_comdef_server::$server_local_strings['meeting_counties_and_sub_provinces'] = isset($meeting_counties_and_sub_provinces) && is_string($meeting_counties_and_sub_provinces)
+                    ? collect(explode(',', $meeting_counties_and_sub_provinces))->map(fn($id) => trim($id))->toArray()
+                    : ($meeting_counties_and_sub_provinces ?? []);
+                c_comdef_server::$server_local_strings['meeting_states_and_provinces'] = isset($meeting_states_and_provinces) && is_string($meeting_states_and_provinces)
+                    ? collect(explode(',', $meeting_states_and_provinces))->map(fn($id) => trim($id))->toArray()
+                    : ($meeting_states_and_provinces ?? []);
                 c_comdef_server::$server_local_strings['google_api_key'] = isset($gkey) ? $gkey : '';
                 c_comdef_server::$server_local_strings['dbPrefix'] = $dbPrefix;
                 c_comdef_server::$server_local_strings['region_bias'] = isset($region_bias) ? $region_bias : 'us';


### PR DESCRIPTION
allows to set meeting_counties_and_sub_provinces and  meeting_states_and_provinces in docker

IE.  `MEETING_STATES_AND_PROVINCES=MA,NH,VT,ME`
