### PR TITLE
reset meetingIds if not searching by meeting

### DIFF
--- a/src/resources/js/components/MeetingsList.svelte
+++ b/src/resources/js/components/MeetingsList.svelte
@@ -69,6 +69,8 @@
     if (isCommaSeparatedNumbers(searchTerm)) {
       meetingIds = searchTerm;
       searchTerm = '';
+    } else {
+      meetingIds = '';
     }
     getMeetings(searchTerm, selectedDays.join(','), selectedServiceBodies.join(','), meetingIds);
   }


### PR DESCRIPTION
when searching for a meeting if you first search by meeting id then change to search by string it would still search by id. this fixes that