### PR TITLE
update missed aggregator  DB statement for Laravel 10 compatibility

### DIFF
--- a/src/app/Console/Commands/ImportRootServers.php
+++ b/src/app/Console/Commands/ImportRootServers.php
@@ -256,7 +256,8 @@ class ImportRootServers extends Command
             $prefix . (new RootServerStatistics)->getTable(),
         ];
         foreach ($tableNames as $tableName) {
-            DB::statement("ANALYZE TABLE $tableName;");
+            $sql = DB::raw("ANALYZE TABLE $tableName;")->getValue(DB::connection()->getQueryGrammar());
+            DB::statement($sql);
         }
     }
 


### PR DESCRIPTION
This was missed in laravel 10 upgrade last year https://github.com/bmlt-enabled/bmlt-root-server/pull/913/files
see https://laravel.com/docs/10.x/upgrade#database-expressions
resolves this error

```
 PDO::prepare(): Argument #1 ($query) must be of type string, Illuminate\Database\Query\Expression given
  at /var/www/html/main_server/vendor/laravel/framework/src/Illuminate/Database/Connection.php:581
    577▕             if ($this->pretending()) {
    578▕                 return true;
    579▕             }
    580▕
  ➜ 581▕             $statement = $this->getPdo()->prepare($query);
    582▕
    583▕             $this->bindValues($statement, $this->prepareBindings($bindings));
    584▕
    585▕             $this->recordsHaveBeenModified();
      +6 vendor frames
  7   /var/www/html/main_server/app/Console/Commands/ImportRootServers.php:259
      Illuminate\Support\Facades\Facade::__callStatic()
  8   /var/www/html/main_server/app/Console/Commands/ImportRootServers.php:68
  ```