### PR TITLE
format things

### DIFF
--- a/src/resources/js/routes/Formats.svelte
+++ b/src/resources/js/routes/Formats.svelte
@@ -101,9 +101,9 @@
     } else {
       const e = format.translations.find((t) => t.language === 'en');
       if (e) {
-        return e.name + ' (' + $translations.noTranslationAvailable + ')';
+        return `(${e.key}) ${e.name} (${$translations.noTranslationAvailable})`;
       } else if (format.translations[0]) {
-        return format.translations[0].name + ' (' + $translations.noTranslationAvailable + ')';
+        return `(${format.translations[0].key}) ${format.translations[0].name} (${$translations.noTranslationAvailable})`;
       } else {
         return '';
       }

--- a/src/resources/js/tests/Formats.spec.ts
+++ b/src/resources/js/tests/Formats.spec.ts
@@ -25,7 +25,7 @@ describe('check content in Formats tab', () => {
     // check for a couple of representative formats
     expect(screen.getByRole('cell', { name: '(C) Closed' })).toBeInTheDocument();
     expect(screen.getByRole('cell', { name: '(BT) Basic Text' })).toBeInTheDocument();
-    expect(screen.getByRole('cell', { name: 'Agnostisch (no English version available)' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '(Ag) Agnostisch (no English version available)' })).toBeInTheDocument();
   });
 
   test('edit a format', async () => {
@@ -87,7 +87,7 @@ describe('check content in Formats tab', () => {
 
   test('check accordion when German is selected', async () => {
     const user = await loginDeutsch('serveradmin', 'Formate');
-    await user.click(await screen.findByRole('cell', { name: 'BasicText' }));
+    await user.click(await screen.findByRole('cell', { name: '(BT) BasicText' }));
     const toggle_de = await screen.findByRole('button', { name: /toggle accordion de/i });
     const toggle_en = await screen.findByRole('button', { name: /toggle accordion en/i });
     const toggle_fr = await screen.findByRole('button', { name: /toggle accordion fr/i });

--- a/src/resources/js/tests/sharedDataAndMocks.ts
+++ b/src/resources/js/tests/sharedDataAndMocks.ts
@@ -1018,8 +1018,13 @@ export async function loginDeutsch(username: string, tab: string | null = null):
   await user.type(await screen.findByLabelText('Passwort'), findPassword(username));
   await user.click(await screen.findByRole('button', { name: 'Anmelden' }));
   if (tab) {
-    const link = await screen.findByRole('link', { name: tab, hidden: true });
-    await user.click(link);
+    await waitFor(
+      async () => {
+        const link = await screen.findByRole('link', { name: tab, hidden: true });
+        await user.click(link);
+      },
+      { timeout: 10000 }
+    );
   }
   return user;
 }


### PR DESCRIPTION
This would change the Format names on Formats page to include the key. `(BT) Basic Text` however with translations you would end up with `(BT) Basic Text ( translation )` or something like that. I'm not sure we want to do this or may need to alter. Alan I'm guessing you'll have idea or opinion on this. 