### PR TITLE
bump svelte / fix pagination

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -47,7 +47,7 @@
                 "prettier-plugin-svelte": "^3.3.3",
                 "prettier-plugin-tailwindcss": "^0.6.11",
                 "sass": "^1.87.0",
-                "svelte": "5.35.2",
+                "svelte": "^5.39.12",
                 "svelte-check": "^4.1.6",
                 "svelte-jester": "^5.0.0",
                 "tailwindcss": "^4.0.0",
@@ -71,6 +71,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
             "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -1948,7 +1949,6 @@
             "version": "2.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
             "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -9123,12 +9123,12 @@
             }
         },
         "node_modules/svelte": {
-            "version": "5.35.2",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.35.2.tgz",
-            "integrity": "sha512-uW/rRXYrhZ7Dh4UQNZ0t+oVGL1dEM+95GavCO8afAk1IY2cPq9BcZv9C3um5aLIya2y8lIeLPxLII9ASGg9Dzw==",
+            "version": "5.39.12",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.39.12.tgz",
+            "integrity": "sha512-CEzwxFuEycokU8K8CE/OuwVbmei+ivu2HvBGYIdASfMa1hCRSNr4RRkzNSvbAvu6h+BOig2CsZTAEY+WKvwZpA==",
             "license": "MIT",
             "dependencies": {
-                "@ampproject/remapping": "^2.3.0",
+                "@jridgewell/remapping": "^2.3.4",
                 "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@sveltejs/acorn-typescript": "^1.0.5",
                 "@types/estree": "^1.0.5",

--- a/src/package.json
+++ b/src/package.json
@@ -40,7 +40,7 @@
         "prettier-plugin-svelte": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "sass": "^1.87.0",
-        "svelte": "5.35.2",
+        "svelte": "^5.39.12",
         "svelte-check": "^4.1.6",
         "svelte-jester": "^5.0.0",
         "tailwindcss": "^4.0.0",

--- a/src/resources/js/components/FormatForm.svelte
+++ b/src/resources/js/components/FormatForm.svelte
@@ -292,11 +292,11 @@
     {/if}
     <div class="md:col-span-2">
       <Label for="worldId" class="mb-2 md:col-span-2">{$translations.nawsFormatTitle}</Label>
-      <Select id="worldId" items={nawsFormats} name="worldId" class="rounded-lg dark:bg-gray-600" />
+      <Select id="worldId" items={nawsFormats} name="worldId" bind:value={$data.worldId} class="rounded-lg dark:bg-gray-600" />
     </div>
     <div class="md:col-span-2">
       <Label for="type" class="mb-2 md:col-span-2">{$translations.formatTypeTitle}</Label>
-      <Select id="type" items={formatTypeCodes} name="type" class="rounded-lg dark:bg-gray-600" />
+      <Select id="type" items={formatTypeCodes} name="type" bind:value={$data.type} class="rounded-lg dark:bg-gray-600" />
     </div>
     <div class="md:col-span-2">
       <Button type="submit" class="w-full" disabled={!$isDirty} onclick={disableButtonHack}>

--- a/src/resources/js/components/MeetingEditForm.svelte
+++ b/src/resources/js/components/MeetingEditForm.svelte
@@ -847,7 +847,7 @@
   <div class="grid gap-4 md:grid-cols-2">
     <div class="md:col-span-2">
       <Label for="timeZone" class="mt-2 mb-2">{$translations.timeZoneTitle}</Label>
-      <Select id="timeZone" name="timeZone" class="rounded-lg dark:bg-gray-600" placeholder={$translations.timeZoneSelectPlaceholder}>
+      <Select id="timeZone" name="timeZone" bind:value={$data.timeZone} class="rounded-lg dark:bg-gray-600" placeholder={$translations.timeZoneSelectPlaceholder}>
         {#each timeZoneGroups as continent}
           <optgroup label={continent.name}>
             {#each continent.values as timezone}
@@ -866,7 +866,7 @@
   <div class="grid gap-4 md:grid-cols-3">
     <div class="w-full">
       <Label for="day" class="mt-2 mb-2">{$translations.dayTitle}</Label>
-      <Select id="day" items={weekdayChoices} name="day" class="rounded-lg dark:bg-gray-600" />
+      <Select id="day" items={weekdayChoices} name="day" bind:value={$data.day} class="rounded-lg dark:bg-gray-600" />
       {#if $errors.day}
         <Helper class="mt-2" color="red">
           {$errors.day}
@@ -895,7 +895,7 @@
   <div class="grid gap-4 md:grid-cols-2">
     <div class="md:col-span-2">
       <Label for="serviceBodyId" class="mt-2 mb-2">{$translations.serviceBodyTitle}</Label>
-      <Select id="serviceBodyId" items={serviceBodyIdItems} name="serviceBodyId" class="rounded-lg dark:bg-gray-600" />
+      <Select id="serviceBodyId" items={serviceBodyIdItems} name="serviceBodyId" bind:value={$data.serviceBodyId} class="rounded-lg dark:bg-gray-600" />
       {#if $errors.serviceBodyId}
         <Helper class="mt-2" color="red">
           {$errors.serviceBodyId}
@@ -947,7 +947,7 @@
   <div class="grid gap-4 md:grid-cols-2">
     <div class="md:col-span-2">
       <Label for="venueType" class="mt-2 mb-2">{$translations.venueTypeTitle}</Label>
-      <Select id="venueType" items={venueTypeItems} name="venueType" class="rounded-lg dark:bg-gray-600" />
+      <Select id="venueType" items={venueTypeItems} name="venueType" bind:value={$data.venueType} class="rounded-lg dark:bg-gray-600" />
       {#if $errors.venueType}
         <Helper class="mt-2" color="red">
           {$errors.venueType}
@@ -1074,7 +1074,7 @@
     <div class="w-full">
       <Label for="locationSubProvince" class="mt-2 mb-2">{$translations.countySubProvinceTitle}</Label>
       {#if countiesAndSubProvincesChoices.length > 0}
-        <Select id="locationSubProvince" items={countiesAndSubProvincesChoices} name="locationSubProvince" class="rounded-lg dark:bg-gray-600" />
+        <Select id="locationSubProvince" items={countiesAndSubProvincesChoices} name="locationSubProvince" bind:value={$data.locationSubProvince} class="rounded-lg dark:bg-gray-600" />
       {:else}
         <Input type="text" id="locationSubProvince" name="locationSubProvince" />
       {/if}
@@ -1089,7 +1089,7 @@
     <div class="w-full">
       <Label for="locationProvince" class="mt-2 mb-2">{$translations.stateTitle}</Label>
       {#if statesAndProvincesChoices.length > 0}
-        <Select id="locationProvince" items={statesAndProvincesChoices} name="locationProvince" class="rounded-lg dark:bg-gray-600" />
+        <Select id="locationProvince" items={statesAndProvincesChoices} name="locationProvince" bind:value={$data.locationProvince} class="rounded-lg dark:bg-gray-600" />
       {:else}
         <Input type="text" id="locationProvince" name="locationProvince" />
       {/if}

--- a/src/resources/js/components/MeetingsList.svelte
+++ b/src/resources/js/components/MeetingsList.svelte
@@ -260,6 +260,12 @@
   $effect(() => {
     updateItemsPerPage();
   });
+  $effect(() => {
+    if (selectedDays || selectedTimes || selectedPublished) {
+      currentPosition = 0;
+      lastEditedMeetingId = null;
+    }
+  });
 </script>
 
 <TableSearch placeholder={$translations.filter} bind:this={tableSearchRef} hoverable={true} bind:inputValue={searchTerm} {divClass} {innerDivClass} {searchClass} {inputClass}>
@@ -413,7 +419,9 @@
             <ChevronLeftOutline size="xs" class="m-1.5" />
           </Button>
           {#each pagesToShow as pageNumber}
-            <Button onclick={() => goToPage(pageNumber)}>{pageNumber}</Button>
+            <Button onclick={() => goToPage(pageNumber)} color={pageNumber === currentPage ? 'primary' : 'alternative'}>
+              {pageNumber}
+            </Button>
           {/each}
           <Button onclick={loadNextPage} disabled={currentPosition + itemsPerPage >= filteredItems.length}>
             <ChevronRightOutline size="xs" class="m-1.5" />

--- a/src/resources/js/components/ServiceBodyForm.svelte
+++ b/src/resources/js/components/ServiceBodyForm.svelte
@@ -21,10 +21,10 @@
   let { selectedServiceBody, serviceBodies, users, onSaveSuccess }: Props = $props();
 
   const parentIdItems = [
-    ...[{ value: '-1', name: $translations.serviceBodiesNoParent ?? '' }],
+    ...[{ value: -1, name: $translations.serviceBodiesNoParent ?? '' }],
     ...serviceBodies
       .filter((sb) => selectedServiceBody?.id !== sb.id)
-      .map((sb) => ({ value: sb.id.toString(), name: sb.name }))
+      .map((sb) => ({ value: sb.id, name: sb.name }))
       .sort((a, b) => a.name.localeCompare(b.name))
   ];
   const userIdToUser = Object.fromEntries(users.map((u) => [u.id, u]));
@@ -171,7 +171,7 @@
     </div>
     <div class="md:col-span-2 {$authenticatedUser?.type !== 'admin' ? 'hidden' : ''}">
       <Label for="adminUserId" class="mb-2">{$translations.adminTitle}</Label>
-      <Select id="adminUserId" items={adminUserItems} name="adminUserId" class="rounded-lg dark:bg-gray-600" disabled={$authenticatedUser?.type !== 'admin'} />
+      <Select id="adminUserId" items={adminUserItems} bind:value={$data.adminUserId} name="adminUserId" class="rounded-lg dark:bg-gray-600" disabled={$authenticatedUser?.type !== 'admin'} />
       <Helper class="mt-2" color="red">
         {#if $errors.adminUserId}
           {$errors.adminUserId}
@@ -180,7 +180,7 @@
     </div>
     <div class={$authenticatedUser?.type !== 'admin' ? 'hidden' : ''}>
       <Label for="type" class="mb-2">{$translations.serviceBodyTypeTitle}</Label>
-      <Select id="type" items={typeItems} name="type" class="rounded-lg dark:bg-gray-600" disabled={$authenticatedUser?.type !== 'admin'} />
+      <Select id="type" items={typeItems} name="type" bind:value={$data.type} class="rounded-lg dark:bg-gray-600" disabled={$authenticatedUser?.type !== 'admin'} />
       <Helper class="mt-2" color="red">
         {#if $errors.type}
           {$errors.type}
@@ -189,7 +189,7 @@
     </div>
     <div class={$authenticatedUser?.type !== 'admin' ? 'hidden' : ''}>
       <Label for="parentId" class="mb-2">{$translations.parentIdTitle}</Label>
-      <Select id="parentId" items={parentIdItems} name="parentId" class="rounded-lg dark:bg-gray-600" disabled={$authenticatedUser?.type !== 'admin'} />
+      <Select id="parentId" items={parentIdItems} name="parentId" bind:value={$data.parentId} class="rounded-lg dark:bg-gray-600" disabled={$authenticatedUser?.type !== 'admin'} />
       <Helper class="mt-2" color="red">
         {#if $errors.parentId}
           {$errors.parentId}

--- a/src/resources/js/components/UserForm.svelte
+++ b/src/resources/js/components/UserForm.svelte
@@ -21,7 +21,7 @@
 
   const userOwnerItems = users
     .filter((u) => selectedUser?.id !== u.id)
-    .map((u) => ({ value: u.id.toString(), name: u.displayName }))
+    .map((u) => ({ value: u.id, name: u.displayName }))
     .sort((a, b) => a.name.localeCompare(b.name));
   const USER_TYPE_DEACTIVATED = 'deactivated';
   const USER_TYPE_OBSERVER = 'observer';
@@ -145,7 +145,7 @@
     </div>
     <div class={$authenticatedUser?.type !== 'admin' ? 'hidden' : ''}>
       <Label for="type" class="mb-2">{$translations.userTypeTitle}</Label>
-      <Select id="type" items={userTypeItems} name="type" class="rounded-lg dark:bg-gray-600" disabled={$authenticatedUser?.type !== 'admin'} />
+      <Select id="type" items={userTypeItems} name="type" bind:value={$data.type} class="rounded-lg dark:bg-gray-600" disabled={$authenticatedUser?.type !== 'admin'} />
       <Helper class="mt-2" color="red">
         {#if $errors.type}
           {$errors.type}
@@ -154,7 +154,7 @@
     </div>
     <div class={$authenticatedUser?.type !== 'admin' ? 'hidden' : ''}>
       <Label for="ownerId" class="mb-2">{$translations.ownedByTitle}</Label>
-      <Select id="ownerId" items={userOwnerItems} name="ownerId" class="rounded-lg dark:bg-gray-600" disabled={$authenticatedUser?.type !== 'admin'} />
+      <Select id="ownerId" items={userOwnerItems} name="ownerId" bind:value={$data.ownerId} class="rounded-lg dark:bg-gray-600" disabled={$authenticatedUser?.type !== 'admin'} />
       <Helper class="mt-2" color="red">
         {#if $errors.ownerId}
           {$errors.ownerId}


### PR DESCRIPTION
this resets the selected meeting list page when filtering and fixes the issue we had with having to pin svelte version. 

with Svelte 5.35.2's PR #16309, Svelte's own select initialization logic runs during the mounting phase which conflicts with felte and creates a race condition. Instead we use bind:value directive to create two-way binding directly between the select element and Felte's reactive $data store

closes https://github.com/bmlt-enabled/bmlt-server/issues/1277
