### PR TITLE
change strlen to mb_strlen for SearchString

### DIFF
--- a/src/app/Http/Controllers/Query/SwitcherController.php
+++ b/src/app/Http/Controllers/Query/SwitcherController.php
@@ -196,7 +196,7 @@ class SwitcherController extends Controller
         $searchString = $request->input('SearchString');
         $searchString = !is_null($searchString) ? trim($searchString) : null;
         if (!is_null($searchString)) {
-            $searchString = strlen($searchString) > 2 || is_numeric($searchString) ? $searchString : null;
+            $searchString = mb_strlen($searchString) > 2 || is_numeric($searchString) ? $searchString : null;
         }
         $searchStringIsAddress = !is_null($searchString) && $request->input('StringSearchIsAnAddress') == '1';
         if (!is_null($searchString) && $searchStringIsAddress) {


### PR DESCRIPTION
There are two other usages of `strlen()` that I opted not to change.

1. One has to do with determining whether to store data in the meetings `data` vs `longdata` tables. I opted not to change this instance because the logic depends on MySQL's storage engine using the same encoding as the submitted string. This is not a guarantee, and if we get it wrong it could result in the code trying to write strings longer than the column's limit. Perhaps we should change this instance, but it'll require a bit more time and consideration.
2. The other has to do with parsing submitted datetimes. This API expects ascii characters, so strlen should be fine.

Partially addresses https://github.com/bmlt-enabled/bmlt-server/issues/1309.