### PR TITLE
Force PHP to always check for file mods when debugging.

### DIFF
--- a/docker/Dockerfile-debug
+++ b/docker/Dockerfile-debug
@@ -6,6 +6,9 @@ ENV PHP_INI_PATH=/etc/php/${PHP_VERSION}/apache2/php.ini
 ENV PHP_CLI_INI_PATH=/etc/php/${PHP_VERSION}/cli/php.ini
 ENV PHP_XDEBUG_ENABLED=1
 
+RUN echo "opcache.revalidate_freq=0" >> ${PHP_INI_PATH}
+RUN echo "opcache.revalidate_freq=0" >> ${PHP_CLI_INI_PATH}
+
 RUN echo "zend_extension=$(find /usr/lib/php/ -name xdebug.so)" >> ${PHP_INI_PATH} \
     && echo "xdebug.mode=coverage,debug" >> ${PHP_INI_PATH} \
     && echo "xdebug.client_port=9003" >> ${PHP_INI_PATH} \


### PR DESCRIPTION
Once PHP loads a file into its opcache, it assumes (by default) that the file won't change for 2 seconds. When I'm running in a docker image, that's too long: I have made a code change and re-request in less than that, and when I do the change doesn't take. Since performance is not paramount when debugging locally, it's safer to force a revalidate (which is just a timestamp check) on every access to a file.