### PR TITLE
Correctly map JS 'da' to database 'dk'.

### DIFF
--- a/src/resources/js/routes/Formats.svelte
+++ b/src/resources/js/routes/Formats.svelte
@@ -96,7 +96,7 @@
   // English; if no English version, then just pick the first one in the array.  If that doesn't exist either then return a blank.
   // This last case only arises when trying to create a format with no translations; the UI signals an error if that happens.
   export function getFormatName(format: Format): string {
-    const n = format.translations.find((t) => t.language === language);
+    const n = format.translations.find((t) => t.language === (language == 'da' ? 'dk' : language));
     if (n) {
       return `(${n.key}) ${n.name}`;
     } else {


### PR DESCRIPTION
When we look up format names in the database, we have to correct the UI's code for Dansk to match the database's code for Dansk.