### PR TITLE
Fix color of chevron in BasicAccordion.

### DIFF
--- a/src/resources/js/components/BasicAccordion.svelte
+++ b/src/resources/js/components/BasicAccordion.svelte
@@ -25,11 +25,11 @@
     <span class="w-full">{header}</span>
 
     {#if open}
-      <svg class="h-3 w-3 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+      <svg class="h-3 w-3 text-gray-300 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5 5 1 1 5" />
       </svg>
     {:else}
-      <svg class="h-3 w-3 text-gray-800 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+      <svg class="h-3 w-3 text-gray-300 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4" />
       </svg>
     {/if}


### PR DESCRIPTION
The basic accordion has a dark background, and the open/close chevron was being drawn in the same color as the background, so it's invisible. This adjusts the chevron color to be the same as the heading text.