### PR TITLE
fix duplicate loading of meeting changes

### DIFF
--- a/src/resources/js/components/BasicTabs.svelte
+++ b/src/resources/js/components/BasicTabs.svelte
@@ -9,6 +9,7 @@
     inactiveClasses?: string;
     activeClasses?: string;
     activeTab?: number;
+    onTabChange?: (index: number) => void;
   }
 
   let {
@@ -17,11 +18,15 @@
     tabsSnippets,
     inactiveClasses = 'p-4 text-primary-600 bg-gray-100 rounded-t-lg dark:bg-gray-700 dark:text-gray-200 px-3.5 py-2.5 text-xs sm:px-5 sm:py-3 sm:text-sm relative',
     activeClasses = 'p-4 text-gray-500 bg-white rounded-t-lg hover:text-gray-600 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white px-3.5 py-2.5 text-xs sm:px-5 sm:py-3 sm:text-sm relative',
-    activeTab = 0
+    activeTab = 0,
+    onTabChange
   }: Props = $props();
 
   function setActiveTab(index: number) {
     activeTab = index;
+    if (onTabChange) {
+      onTabChange(index);
+    }
   }
 </script>
 

--- a/src/resources/js/lang/da.ts
+++ b/src/resources/js/lang/da.ts
@@ -217,6 +217,7 @@ export const daTranslations = {
   nawsFormat_Y: 'Young People',
   nawsFormatTitle: 'NAWS Format',
   neighborhoodTitle: 'Neighborhood',
+  noChangesFound: 'No changes found',
   noFormatTranslationsError: 'At least one translation is required.',
   noLogsFound: 'No logs found',
   nominatimGeocodingFailed: 'Nominatim geocoding failed: no results found',

--- a/src/resources/js/lang/de.ts
+++ b/src/resources/js/lang/de.ts
@@ -163,6 +163,7 @@ export const deTranslations = {
   nawsFormat_Y: 'Junge Menschen',
   nawsFormatTitle: 'NAWS Format',
   neighborhoodTitle: 'Nachbarschaft',
+  noChangesFound: 'No changes found',
   noFormatTranslationsError: 'Es ist mindestens eine Übersetzung erforderlich.',
   noLogsFound: 'No logs found',
   nominatimGeocodingFailed: 'Nominatim-geocoding fehler: keine Ergebnisse gefunden',

--- a/src/resources/js/lang/en.ts
+++ b/src/resources/js/lang/en.ts
@@ -217,6 +217,7 @@ export const enTranslations = {
   nawsFormat_Y: 'Young People',
   nawsFormatTitle: 'NAWS Format',
   neighborhoodTitle: 'Neighborhood',
+  noChangesFound: 'No changes found',
   noFormatTranslationsError: 'At least one translation is required.',
   noLogsFound: 'No logs found',
   nominatimGeocodingFailed: 'Nominatim geocoding failed: no results found',

--- a/src/resources/js/lang/es.ts
+++ b/src/resources/js/lang/es.ts
@@ -217,6 +217,7 @@ export const esTranslations = {
   nawsFormat_Y: 'Jóvenes',
   nawsFormatTitle: 'Formato Servicios Mundiales de NA',
   neighborhoodTitle: 'Barrio/vecindario',
+  noChangesFound: 'No changes found',
   noFormatTranslationsError: 'Se requiere por lo menos una traducción',
   noLogsFound: 'Los registros no se encuentran',
   nominatimGeocodingFailed: 'Nominatim geocoding failed: no results found',

--- a/src/resources/js/lang/fa.ts
+++ b/src/resources/js/lang/fa.ts
@@ -217,6 +217,7 @@ export const faTranslations = {
   nawsFormat_Y: 'Young People',
   nawsFormatTitle: 'فرمت NAWS',
   neighborhoodTitle: 'محله',
+  noChangesFound: 'No changes found',
   noFormatTranslationsError: 'حداقل یک ترجمه لازم است.',
   noLogsFound: 'هیچ گزارشی یافت نشد',
   nominatimGeocodingFailed: 'Nominatim geocoding failed: no results found',

--- a/src/resources/js/lang/fr.ts
+++ b/src/resources/js/lang/fr.ts
@@ -217,6 +217,7 @@ export const frTranslations = {
   nawsFormat_Y: 'Jeunes',
   nawsFormatTitle: 'Format NAWS',
   neighborhoodTitle: 'Quartier',
+  noChangesFound: 'No changes found',
   noFormatTranslationsError: 'Au moins une traduction est requise.',
   noLogsFound: 'Aucun journal trouvé',
   nominatimGeocodingFailed: 'Nominatim geocoding failed: no results found',

--- a/src/resources/js/lang/it.ts
+++ b/src/resources/js/lang/it.ts
@@ -217,6 +217,7 @@ export const itTranslations = {
   nawsFormat_Y: 'Young People',
   nawsFormatTitle: 'NAWS Format',
   neighborhoodTitle: 'Neighborhood',
+  noChangesFound: 'No changes found',
   noFormatTranslationsError: 'At least one translation is required.',
   noLogsFound: 'No logs found',
   nominatimGeocodingFailed: 'Nominatim geocoding failed: no results found',

--- a/src/resources/js/lang/pl.ts
+++ b/src/resources/js/lang/pl.ts
@@ -217,6 +217,7 @@ export const plTranslations = {
   nawsFormat_Y: 'Young People',
   nawsFormatTitle: 'NAWS Format',
   neighborhoodTitle: 'Neighborhood',
+  noChangesFound: 'No changes found',
   noFormatTranslationsError: 'At least one translation is required.',
   noLogsFound: 'No logs found',
   nominatimGeocodingFailed: 'Nominatim geocoding failed: no results found',

--- a/src/resources/js/lang/pt.ts
+++ b/src/resources/js/lang/pt.ts
@@ -217,6 +217,7 @@ export const ptTranslations = {
   nawsFormat_Y: 'Young People',
   nawsFormatTitle: 'NAWS Format',
   neighborhoodTitle: 'Neighborhood',
+  noChangesFound: 'No changes found',
   noFormatTranslationsError: 'At least one translation is required.',
   noLogsFound: 'No logs found',
   nominatimGeocodingFailed: 'Nominatim geocoding failed: no results found',

--- a/src/resources/js/lang/ru.ts
+++ b/src/resources/js/lang/ru.ts
@@ -217,6 +217,7 @@ export const ruTranslations = {
   nawsFormat_Y: 'Young People',
   nawsFormatTitle: 'NAWS Format',
   neighborhoodTitle: 'Neighborhood',
+  noChangesFound: 'No changes found',
   noFormatTranslationsError: 'At least one translation is required.',
   noLogsFound: 'No logs found',
   nominatimGeocodingFailed: 'Nominatim geocoding failed: no results found',

--- a/src/resources/js/lang/sv.ts
+++ b/src/resources/js/lang/sv.ts
@@ -217,6 +217,7 @@ export const svTranslations = {
   nawsFormat_Y: 'Young People',
   nawsFormatTitle: 'NAWS Format',
   neighborhoodTitle: 'Neighborhood',
+  noChangesFound: 'No changes found',
   noFormatTranslationsError: 'At least one translation is required.',
   noLogsFound: 'No logs found',
   nominatimGeocodingFailed: 'Nominatim geocoding failed: no results found',


### PR DESCRIPTION
Fixed the flickering/dimming issue when opening meeting modals by removing the global spinner from the changes API call that was triggering immediately on modal open. Implemented lazy loading so changes are only fetched when the user clicks the "Changes" tab. Changes were actually being loaded like 3 times due to getChanges() being an effect