### PR TITLE
fix loading of protected routes with user details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix favicon.
 * Mask visibility=1 fields with asterisks in GetChanges json_data for unauthorized users.
 * Fixed an issue where a service body couldn't be edited if one of its meeting editor users had been deleted.
+* Fixed admin routes failing to load when accessed via direct URL or bookmark.
 
 ## 4.0.1 (November 5, 2025)
 * Fixed longitude/latitude fields to be read-only when auto-geocoding is enabled

--- a/src/resources/js/App.svelte
+++ b/src/resources/js/App.svelte
@@ -54,11 +54,28 @@
   }
 
   function requiresAuthenticationAdmin(): boolean {
-    return requiresAuthentication() && ($authenticatedUser?.type === 'admin' || $authenticatedUser?.type === 'serviceBodyAdmin');
+    if (!requiresAuthentication()) {
+      return false;
+    }
+    // If $authenticatedUser is null, the user data is still being fetched from the API.
+    // Allow the route to load temporarily, this guard will be re-evaluated reactively once the user loads.
+    // The route components themselves also verify $authenticatedUser before rendering admin-only content.
+    if (!$authenticatedUser) {
+      return true;
+    }
+    return $authenticatedUser.type === 'admin' || $authenticatedUser.type === 'serviceBodyAdmin';
   }
 
   function requiresAuthenticationServerAdmin(): boolean {
-    return requiresAuthentication() && $authenticatedUser?.type === 'admin';
+    if (!requiresAuthentication()) {
+      return false;
+    }
+    // If $authenticatedUser is null, the user data is still being fetched from the API.
+    // Allow the route to load temporarily, this guard will be re-evaluated reactively once the user loads.
+    if (!$authenticatedUser) {
+      return true;
+    }
+    return $authenticatedUser.type === 'admin';
   }
 
   function conditionsFailed(event: ConditionsFailedEvent) {


### PR DESCRIPTION
this was happening due to mismatch between synchronous route guards and asynchronous authentication, the router evaluates conditions immediate and expects a boolean back right  away. getting the user data needed for those pages is asynchronous