### PR TITLE
remove unused meeting_time_zones_enabled setting

### DIFF
--- a/src/app/Http/Controllers/Query/SwitcherController.php
+++ b/src/app/Http/Controllers/Query/SwitcherController.php
@@ -560,7 +560,6 @@ class SwitcherController extends Controller
             'google_api_key' => legacy_config('aggregator_mode_enabled') ? null : legacy_config('google_api_key', ''),
             'dbVersion' => $this->migrationRepository->getLastMigration()['migration'],
             'dbPrefix' => legacy_config('db_prefix'),
-            'meeting_time_zones_enabled' => legacy_config('meeting_time_zones_enabled') ? '1' : '0',
             'phpVersion' => phpversion(),
             'auto_geocoding_enabled' => legacy_config('auto_geocoding_enabled'),
             'county_auto_geocoding_enabled' => legacy_config('county_auto_geocoding_enabled'),

--- a/src/app/LegacyConfig.php
+++ b/src/app/LegacyConfig.php
@@ -117,7 +117,6 @@ class LegacyConfig
         $config['meeting_counties_and_sub_provinces'] = isset($meeting_counties_and_sub_provinces) && is_string($meeting_counties_and_sub_provinces)
             ? collect(explode(',', $meeting_counties_and_sub_provinces))->map(fn($id) => trim($id))->toArray()
             : ($meeting_counties_and_sub_provinces ?? []);
-        $config['meeting_time_zones_enabled'] = isset($meeting_time_zones_enabled) && $meeting_time_zones_enabled;
         $config['search_spec_map_center_longitude'] = isset($search_spec_map_center) && is_array($search_spec_map_center) && isset($search_spec_map_center['longitude']) ? $search_spec_map_center['longitude'] : -118.563659;
         $config['search_spec_map_center_latitude'] = isset($search_spec_map_center) && is_array($search_spec_map_center) && isset($search_spec_map_center['latitude']) ? $search_spec_map_center['latitude'] : 34.235918;
         $config['search_spec_map_center_zoom'] = isset($search_spec_map_center) && is_array($search_spec_map_center) && isset($search_spec_map_center['zoom']) ? $search_spec_map_center['zoom'] : 6;

--- a/src/tests/Feature/GetServerInfoTest.php
+++ b/src/tests/Feature/GetServerInfoTest.php
@@ -167,19 +167,6 @@ class GetServerInfoTest extends TestCase
             ->assertJsonFragment(['google_api_key' => 'blah']);
     }
 
-    public function testMeetingTimeZonesEnabled()
-    {
-        LegacyConfig::set('meeting_time_zones_enabled', true);
-        $this->get('/client_interface/json/?switcher=GetServerInfo')
-            ->assertStatus(200)
-            ->assertJsonFragment(['meeting_time_zones_enabled' => '1']);
-
-        LegacyConfig::set('meeting_time_zones_enabled', false);
-        $this->get('/client_interface/json/?switcher=GetServerInfo')
-            ->assertStatus(200)
-            ->assertJsonFragment(['meeting_time_zones_enabled' => '0']);
-    }
-
     public function testCenterLongitude()
     {
         LegacyConfig::remove('search_spec_map_center_longitude');


### PR DESCRIPTION
This setting is not being used anywhere and nothing ever consumed it from GetServerInfo. Time zones are enabled and enforced by default for 4.x all new meeting saves or creations must have timezone. 