### PR TITLE
Strip legacy #@-@# separator from custom field values in UI display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed a geocoding issue -- if the county and/or zip code is automatically computed by the geocoder, we don't want to feed old and possibly incorrect values to the geocoder if the user edits an address.
 * Fixed problems with format key validation -- server now checks for duplicate keys correctly, and disallows changes to the English keys for the reserved formats HY, TC, and VM.
 * Added Portuguese translations.
+* Strip legacy `#@-@#` separator from custom field values in UI display.
 
 ## 4.0.2 (November 11, 2025)
 * Added Italian translations.

--- a/src/resources/js/components/MeetingEditForm.svelte
+++ b/src/resources/js/components/MeetingEditForm.svelte
@@ -16,7 +16,7 @@
   import { spinner } from '../stores/spinner';
   import type { MeetingChangeResource } from 'bmlt-server-client';
   import RootServerApi from '../lib/ServerApi';
-  import { formIsDirty, isDirty as globalIsDirty } from '../lib/utils';
+  import { formIsDirty, isDirty as globalIsDirty, stripLegacyFieldSeparator } from '../lib/utils';
   import { timeZones, timeZoneGroups } from '../lib/timeZone/timeZones';
   import { tzFind } from '../lib/timeZone/find';
   import { Geocoder } from '../lib/geocoder';
@@ -147,13 +147,13 @@
     contactPhone2: selectedMeeting?.contactPhone2 ?? '',
     contactEmail1: selectedMeeting?.contactEmail1 ?? '',
     contactEmail2: selectedMeeting?.contactEmail2 ?? '',
-    busLines: selectedMeeting?.busLines ?? '',
-    trainLines: selectedMeeting?.trainLines ?? '',
+    busLines: stripLegacyFieldSeparator(selectedMeeting?.busLines),
+    trainLines: stripLegacyFieldSeparator(selectedMeeting?.trainLines),
     comments: selectedMeeting?.comments ?? '',
     customFields: selectedMeeting?.customFields
       ? {
           ...Object.fromEntries(settings.customFields.map((field) => [field.name, ''])),
-          ...Object.fromEntries(Object.entries(selectedMeeting.customFields).map(([key, value]) => [key, value ?? '']))
+          ...Object.fromEntries(Object.entries(selectedMeeting.customFields).map(([key, value]) => [key, stripLegacyFieldSeparator(value)]))
         }
       : Object.fromEntries(settings.customFields.map((field) => [field.name, '']))
   };

--- a/src/resources/js/lib/utils.ts
+++ b/src/resources/js/lib/utils.ts
@@ -61,3 +61,19 @@ export function isCommaSeparatedNumbers(str: string): boolean {
   const regex: RegExp = /^(\d+)(,\d+)*$/;
   return regex.test(str);
 }
+
+/**
+ * Strips legacy BMLT v2 field separator from custom field values.
+ * "Display Name#@-@#Value" -> "Value"
+ */
+export function stripLegacyFieldSeparator(value: string | null | undefined): string {
+  if (!value) return '';
+
+  const separator = '#@-@#';
+  if (value.includes(separator)) {
+    const parts = value.split(separator);
+    return parts[1]?.trim() || value;
+  }
+
+  return value;
+}

--- a/src/resources/js/tests/utils.spec.ts
+++ b/src/resources/js/tests/utils.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { stripLegacyFieldSeparator } from '../lib/utils';
+
+describe('stripLegacyFieldSeparator', () => {
+  it('should strip legacy separator and return value', () => {
+    expect(stripLegacyFieldSeparator('Bus Lines#@-@#16')).toBe('16');
+    expect(stripLegacyFieldSeparator('Train Lines#@-@#Green Line D')).toBe('Green Line D');
+    expect(stripLegacyFieldSeparator('Boat Line#@-@#Steamship Authority')).toBe('Steamship Authority');
+  });
+
+  it('should return unchanged value when no separator present', () => {
+    expect(stripLegacyFieldSeparator('16')).toBe('16');
+    expect(stripLegacyFieldSeparator('Green Line D')).toBe('Green Line D');
+    expect(stripLegacyFieldSeparator('Regular value')).toBe('Regular value');
+  });
+
+  it('should handle null and undefined values', () => {
+    expect(stripLegacyFieldSeparator(null)).toBe('');
+    expect(stripLegacyFieldSeparator(undefined)).toBe('');
+  });
+
+  it('should handle empty string', () => {
+    expect(stripLegacyFieldSeparator('')).toBe('');
+  });
+
+  it('should trim whitespace from extracted value', () => {
+    expect(stripLegacyFieldSeparator('Bus Lines#@-@#  16  ')).toBe('16');
+    expect(stripLegacyFieldSeparator('Train Lines#@-@#   Green Line D   ')).toBe('Green Line D');
+  });
+
+  it('should handle multiple separators by using only the first split', () => {
+    // split with limit 2 means only first occurrence is split
+    expect(stripLegacyFieldSeparator('First#@-@#Second#@-@#Third')).toBe('Second');
+  });
+
+  it('should return original value if nothing after separator', () => {
+    expect(stripLegacyFieldSeparator('Bus Lines#@-@#')).toBe('Bus Lines#@-@#');
+  });
+});


### PR DESCRIPTION
closes https://github.com/bmlt-enabled/bmlt-server/issues/1390  this mimics same behavior in old UI