### PR TITLE
Add frontend translation helper cmds

### DIFF
--- a/src/app/Console/Commands/AddTranslationKey.php
+++ b/src/app/Console/Commands/AddTranslationKey.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+/**
+* # Add a new key
+* php artisan translation:add meetingName "Meeting Name"
+*
+* # Update an existing key (with --force)
+* php artisan translation:add cancel "Cancelled" --force
+*
+**/
+
+class AddTranslationKey extends Command
+{
+    protected $signature = 'translation:add {key} {value} {--force : Overwrite existing keys}';
+
+    protected $description = 'Add a translation key/value to all language files in alphabetical order';
+
+    public function handle()
+    {
+        $key = $this->argument('key');
+        $value = $this->argument('value');
+
+        if (!preg_match('/^[a-z][a-zA-Z0-9]*$/', $key)) {
+            $this->error("Invalid key format. Key must be in camelCase (start with lowercase letter, no underscores or spaces).");
+            return 1;
+        }
+
+        $langPath = resource_path('js/lang');
+        $files = File::glob($langPath . '/*.ts');
+
+        $files = array_filter($files, fn($file) => basename($file) !== 'index.ts');
+
+        if (empty($files)) {
+            $this->error("No translation files found in {$langPath}");
+            return 1;
+        }
+
+        $this->info("Adding translation key '{$key}' to all language files...");
+
+        foreach ($files as $file) {
+            $this->processFile($file, $key, $value);
+        }
+
+        $this->info("\n✓ Translation key '{$key}' added to all language files.");
+        if (!$this->option('force')) {
+            $this->info("Note: Non-English files have been marked with '// TODO: translate' comments.");
+        }
+
+        return 0;
+    }
+
+    private function processFile(string $filePath, string $key, string $value): void
+    {
+        $fileName = basename($filePath);
+        $content = File::get($filePath);
+
+        $isEnglish = str_starts_with($fileName, 'en.');
+
+        $translationValue = $isEnglish ? $value : $value;
+        $comment = $isEnglish ? '' : ', // TODO: translate';
+
+        // Find the translations export (e.g., export const enTranslations = {)
+        if (!preg_match('/export const \w+Translations = \{/', $content, $matches, PREG_OFFSET_CAPTURE)) {
+            $this->error("Could not find translations export in {$fileName}");
+            return;
+        }
+
+        $exportStart = $matches[0][1] + strlen($matches[0][0]);
+
+        $closingBracePos = $this->findClosingBrace($content, $exportStart);
+
+        if ($closingBracePos === false) {
+            $this->error("Could not find closing brace for translations in {$fileName}");
+            return;
+        }
+
+        // Extract the translations section
+        $translationsContent = substr($content, $exportStart, $closingBracePos - $exportStart);
+
+        // Parse existing keys
+        preg_match_all('/^\s*(\w+):/m', $translationsContent, $keyMatches);
+        $existingKeys = $keyMatches[1];
+
+        // Check if key already exists
+        if (in_array($key, $existingKeys)) {
+            if (!$this->option('force')) {
+                $this->warn("  {$fileName}: Key '{$key}' already exists, skipping. Use --force to overwrite.");
+                return;
+            }
+            // Remove the existing key so we can replace it
+            $this->removeExistingKey($translationsContent, $key, $exportStart, $closingBracePos, $content, $filePath, $value, $fileName, $isEnglish);
+            return;
+        }
+
+        // Find insertion point (alphabetically, case-insensitive)
+        $insertAfterKey = null;
+        $insertBeforeKey = null;
+
+        foreach ($existingKeys as $existingKey) {
+            if (strcasecmp($existingKey, $key) < 0) {
+                $insertAfterKey = $existingKey;
+            } else {
+                $insertBeforeKey = $existingKey;
+                break;
+            }
+        }
+
+        // Create the new line
+        // escape single quotes and backslashes
+        $escapedValue = str_replace(['\\', "'"], ['\\\\', "\\'"], $translationValue);
+        $newLine = "  {$key}: '{$escapedValue}'{$comment}";
+
+        // Find the position to insert
+        if ($insertBeforeKey) {
+            // Insert before the next key (add comma after if English, otherwise comment includes comma)
+            if (preg_match('/^\s*' . preg_quote($insertBeforeKey, '/') . ':/m', $translationsContent, $match, PREG_OFFSET_CAPTURE)) {
+                $insertPos = $match[0][1];
+                $comma = $isEnglish ? ',' : '';
+                $beforeInsert = substr($translationsContent, 0, $insertPos);
+                
+                // Insert before a key
+                $afterInsert = substr($translationsContent, $insertPos);
+                
+                // Check if we're at the very start (only whitespace before first key)
+                if (trim($beforeInsert) === '') {
+                    // At the start - ensure we have proper newline formatting
+                    // If $beforeInsert doesn't end with newline, add one
+                    $needsLeadingNewline = !str_ends_with($beforeInsert, "\n");
+                    $prefix = $needsLeadingNewline ? "\n" : '';
+                    // Don't add extra newline at end - $afterInsert already starts at the next key's line
+                    $updatedContent = $beforeInsert . $prefix . $newLine . $comma . $afterInsert;
+                } else {
+                    // There's content before, insert normally
+                    $updatedContent = $beforeInsert . $newLine . $comma . "\n" . $afterInsert;
+                }
+            }
+        } elseif ($insertAfterKey) {
+            // Insert after the previous key (at the end)
+            // Find the end of the last key's line
+            if (preg_match('/^\s*' . preg_quote($insertAfterKey, '/') . ':.*$/m', $translationsContent, $match, PREG_OFFSET_CAPTURE)) {
+                $lineEnd = $match[0][1] + strlen($match[0][0]);
+                $updatedContent = substr($translationsContent, 0, $lineEnd)
+                    . ",\n" . $newLine
+                    . substr($translationsContent, $lineEnd);
+            }
+        } else {
+            // No existing keys, add as first key
+            $updatedContent = "\n" . $newLine . "\n";
+        }
+
+        $newContent = substr($content, 0, $exportStart)
+            . $updatedContent
+            . substr($content, $closingBracePos);
+
+        File::put($filePath, $newContent);
+        $this->info("  ✓ {$fileName}");
+    }
+
+    private function findClosingBrace(string $content, int $startPos): int|false
+    {
+        $depth = 1;
+        $length = strlen($content);
+
+        for ($i = $startPos; $i < $length; $i++) {
+            if ($content[$i] === '{') {
+                $depth++;
+            } elseif ($content[$i] === '}') {
+                $depth--;
+                if ($depth === 0) {
+                    return $i;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function removeExistingKey(
+        string $translationsContent,
+        string $key,
+        int $exportStart,
+        int $closingBracePos,
+        string $content,
+        string $filePath,
+        string $value,
+        string $fileName,
+        bool $isEnglish
+    ): void {
+        // Find the line with the existing key and extract its value
+        $pattern = '/^(\s*)' . preg_quote($key, '/') . ':\s*([\'"])(.*?)\2(,?)(.*?)$/m';
+        if (preg_match($pattern, $translationsContent, $match, PREG_OFFSET_CAPTURE)) {
+            $lineStart = $match[0][1];
+            $indent = $match[1][0];
+            $trailingComma = $match[4][0];
+
+            // Escape the new value
+            $escapedValue = str_replace(['\\', "'"], ['\\\\', "\\'"], $value);
+
+            // Add TODO comment for non-English files
+            $comment = $isEnglish ? '' : ', // TODO: translate';
+
+            // If there's no comma, we need to add one (or use the comment's comma)
+            if (!$trailingComma && !$comment) {
+                $trailingComma = ',';
+            } elseif ($trailingComma && $comment) {
+                // Comment already has comma, don't duplicate
+                $trailingComma = '';
+            }
+
+            $newLine = "{$indent}{$key}: '{$escapedValue}'{$trailingComma}{$comment}";
+
+            // Replace the entire line
+            $beforeLine = substr($translationsContent, 0, $lineStart);
+            $lineEnd = $lineStart + strlen($match[0][0]);
+            $afterLine = substr($translationsContent, $lineEnd);
+
+            $updatedContent = $beforeLine . $newLine . $afterLine;
+
+            // Rebuild the full content
+            $newContent = substr($content, 0, $exportStart)
+                . $updatedContent
+                . substr($content, $closingBracePos);
+
+            File::put($filePath, $newContent);
+            $this->info("  ✓ {$fileName} (updated)");
+        }
+    }
+}

--- a/src/app/Console/Commands/DeleteTranslationKey.php
+++ b/src/app/Console/Commands/DeleteTranslationKey.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+/**
+ * # Delete a key from all language files
+ * php artisan translation:delete oldKey
+ *
+ **/
+
+class DeleteTranslationKey extends Command
+{
+    protected $signature = 'translation:delete {key}';
+
+    protected $description = 'Delete a translation key from all language files';
+
+    public function handle()
+    {
+        $key = $this->argument('key');
+
+        $langPath = resource_path('js/lang');
+        $files = File::glob($langPath . '/*.ts');
+
+        $files = array_filter($files, fn($file) => basename($file) !== 'index.ts');
+
+        if (empty($files)) {
+            $this->error("No translation files found in {$langPath}");
+            return 1;
+        }
+
+        $this->info("Deleting translation key '{$key}' from all language files...");
+
+        $deletedCount = 0;
+        $notFoundCount = 0;
+
+        foreach ($files as $file) {
+            $result = $this->deleteKeyFromFile($file, $key);
+            if ($result) {
+                $deletedCount++;
+            } else {
+                $notFoundCount++;
+            }
+        }
+
+        if ($deletedCount > 0) {
+            $this->info("\n✓ Translation key '{$key}' deleted from {$deletedCount} file(s).");
+        }
+
+        if ($notFoundCount > 0) {
+            $this->warn("Key not found in {$notFoundCount} file(s).");
+        }
+
+        return 0;
+    }
+
+    private function deleteKeyFromFile(string $filePath, string $key): bool
+    {
+        $fileName = basename($filePath);
+        $content = File::get($filePath);
+
+        // Find the translations export (e.g., export const enTranslations = {)
+        if (!preg_match('/export const \w+Translations = \{/', $content, $matches, PREG_OFFSET_CAPTURE)) {
+            $this->error("Could not find translations export in {$fileName}");
+            return false;
+        }
+
+        $exportStart = $matches[0][1] + strlen($matches[0][0]);
+
+        $closingBracePos = $this->findClosingBrace($content, $exportStart);
+
+        if ($closingBracePos === false) {
+            $this->error("Could not find closing brace for translations in {$fileName}");
+            return false;
+        }
+
+        // Extract the translations section
+        $translationsContent = substr($content, $exportStart, $closingBracePos - $exportStart);
+
+        // Find the line with the key
+        $pattern = '/^(\s*)' . preg_quote($key, '/') . ':.*?(?:,\s*(?:\/\/.*)?)?$/m';
+        if (!preg_match($pattern, $translationsContent, $match, PREG_OFFSET_CAPTURE)) {
+            $this->warn("  {$fileName}: Key '{$key}' not found");
+            return false;
+        }
+
+        $lineStart = $match[0][1];
+        $lineLength = strlen($match[0][0]);
+
+        // Remove the line including the newline
+        $beforeLine = substr($translationsContent, 0, $lineStart);
+        $afterLine = substr($translationsContent, $lineStart + $lineLength);
+
+        // Remove the newline after the key
+        if (substr($afterLine, 0, 1) === "\n") {
+            $afterLine = substr($afterLine, 1);
+        }
+
+        // Check if we need to fix comma on the previous line
+        // If the deleted line had no comma and the previous line exists,
+        // and the next content is not the closing brace, we may need to add a comma
+        $hasComma = preg_match('/,\s*(?:\/\/.*)?$/', $match[0][0]);
+
+        if (!$hasComma && trim($afterLine) !== '' && !preg_match('/^\s*}/', $afterLine)) {
+            // The deleted line didn't have a comma, but there's more content after
+            // We need to ensure the previous line has a comma
+            if (preg_match('/^(.*?)(\s*(?:\/\/.*)?)\s*$/s', rtrim($beforeLine, "\n"), $prevMatch)) {
+                $beforeContent = $prevMatch[1];
+                $trailingComment = $prevMatch[2] ?? '';
+
+                // Check if the last line already has a comma
+                if (!preg_match('/,\s*$/', $beforeContent)) {
+                    // Add comma before any trailing comment
+                    $beforeLine = rtrim($beforeContent, " \t") . ',' . $trailingComment . "\n";
+                }
+            }
+        }
+
+        $updatedContent = $beforeLine . $afterLine;
+
+        // Rebuild the full content
+        $newContent = substr($content, 0, $exportStart)
+            . $updatedContent
+            . substr($content, $closingBracePos);
+
+        File::put($filePath, $newContent);
+        $this->info("  ✓ {$fileName}");
+
+        return true;
+    }
+
+    private function findClosingBrace(string $content, int $startPos): int|false
+    {
+        $depth = 1;
+        $length = strlen($content);
+
+        for ($i = $startPos; $i < $length; $i++) {
+            if ($content[$i] === '{') {
+                $depth++;
+            } elseif ($content[$i] === '}') {
+                $depth--;
+                if ($depth === 0) {
+                    return $i;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/app/Console/Commands/UpdateTranslationsFromSpreadsheet.php
+++ b/src/app/Console/Commands/UpdateTranslationsFromSpreadsheet.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+/**
+ * php artisan translation:update-from-spreadsheet /path/to/italian-translations.xlsx it
+ *
+ * Spreadsheet format:
+ * Column A: Key
+ * Column B: English
+ * Column C: Target Language (e.g., Italiano)
+ */
+class UpdateTranslationsFromSpreadsheet extends Command
+{
+    protected $signature = 'translation:update-from-spreadsheet
+                            {spreadsheet : Path to the XLSX file}
+                            {language : Language code (e.g., it, fr, es)}';
+
+    protected $description = 'Update translation file from XLSX spreadsheet';
+
+    public function handle()
+    {
+        $spreadsheetPath = $this->argument('spreadsheet');
+        $languageCode = $this->argument('language');
+
+        if ($languageCode === 'en') {
+            $this->error("Cannot update English translations from spreadsheet.");
+            $this->info("English translations should be updated directly in the source file or using 'translation:add' command.");
+            return 1;
+        }
+
+        if (!file_exists($spreadsheetPath)) {
+            $this->error("Spreadsheet file not found: {$spreadsheetPath}");
+            return 1;
+        }
+
+        $langPath = resource_path("js/lang/{$languageCode}.ts");
+        if (!File::exists($langPath)) {
+            $this->error("Translation file not found: {$langPath}");
+            $this->info("Available languages: " . implode(', ', $this->getAvailableLanguages()));
+            return 1;
+        }
+
+        try {
+            $this->info("Reading spreadsheet: {$spreadsheetPath}");
+            $translations = $this->parseSpreadsheet($spreadsheetPath);
+
+            if (empty($translations)) {
+                $this->error("No translations found in spreadsheet");
+                return 1;
+            }
+
+            $this->info("Found " . count($translations) . " translations in spreadsheet");
+
+            $backupFile = "{$langPath}.backup." . time();
+            File::copy($langPath, $backupFile);
+            $this->info("Created backup: {$backupFile}");
+
+            $this->info("Updating {$languageCode}.ts...");
+            $result = $this->updateTranslationFile($langPath, $translations);
+
+            $this->info("\n📊 Translation summary:");
+            $this->info("   • Keys found in spreadsheet: " . count($translations));
+            $this->info("   • Updated existing keys: {$result['updated']}");
+            $this->info("   • Keys not found in file: {$result['notFound']}");
+
+            if ($result['notFound'] > 0) {
+                $this->warn("\nKeys not found in {$languageCode}.ts:");
+                foreach ($result['notFoundKeys'] as $key) {
+                    $this->warn("  • {$key}");
+                }
+                $this->warn("\nUse 'translation:add' command to add new keys first");
+            }
+
+            $this->info("\n✅ Translation file updated successfully!");
+            $this->info("📁 Backup created at: {$backupFile}");
+
+            return 0;
+        } catch (\Exception $e) {
+            $this->error("Error: " . $e->getMessage());
+            return 1;
+        }
+    }
+
+    private function parseSpreadsheet(string $filePath): array
+    {
+        $spreadsheet = IOFactory::load($filePath);
+        $sheet = $spreadsheet->getActiveSheet();
+        $highestRow = $sheet->getHighestRow();
+
+        $translations = [];
+
+        // Start from row 2 (skip header: Key, English, Target Language)
+        for ($row = 2; $row <= $highestRow; $row++) {
+            $key = trim((string) $sheet->getCell("A{$row}")->getValue());
+            // Column C contains the target language translation
+            $value = trim((string) $sheet->getCell("C{$row}")->getValue());
+
+            if ($key && $value) {
+                $translations[$key] = $value;
+            }
+        }
+
+        return $translations;
+    }
+
+    private function updateTranslationFile(string $filePath, array $newTranslations): array
+    {
+        $content = File::get($filePath);
+        $updated = 0;
+        $notFound = 0;
+        $notFoundKeys = [];
+
+        foreach ($newTranslations as $key => $newValue) {
+            // Escape the new value for single quotes
+            $escapedValue = str_replace(['\\', "'"], ['\\\\', "\\'"], $newValue);
+
+            // Match the key with its current value (both single and double quotes)
+            $pattern = '/^(\s*)' . preg_quote($key, '/') . ':\s*([\'"])(.*)\\2(,?)(.*?)$/m';
+
+            if (preg_match($pattern, $content, $match)) {
+                $indent = $match[1];
+                $comma = $match[4];
+                $restOfLine = $match[5]; // This captures comments like // TODO: translate
+
+                // Build the replacement line with single quotes
+                $replacement = "{$indent}{$key}: '{$escapedValue}'{$comma}{$restOfLine}";
+
+                $content = preg_replace($pattern, $replacement, $content, 1);
+                $updated++;
+            } else {
+                $notFound++;
+                $notFoundKeys[] = $key;
+            }
+        }
+
+        File::put($filePath, $content);
+
+        return [
+            'updated' => $updated,
+            'notFound' => $notFound,
+            'notFoundKeys' => $notFoundKeys,
+        ];
+    }
+
+    private function getAvailableLanguages(): array
+    {
+        $langPath = resource_path('js/lang');
+        $files = File::glob($langPath . '/*.ts');
+
+        return array_map(function ($file) {
+            $basename = basename($file, '.ts');
+            return $basename !== 'index' ? $basename : null;
+        }, array_filter($files, fn($file) => basename($file) !== 'index.ts'));
+    }
+}

--- a/src/tests/Feature/AddTranslationKeyTest.php
+++ b/src/tests/Feature/AddTranslationKeyTest.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class AddTranslationKeyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $testTranslationFilePath;
+    private string $testTranslationFilePath2;
+    private array $savedFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testTranslationFilePath = resource_path('js/lang/test.ts');
+        $this->testTranslationFilePath2 = resource_path('js/lang/test2.ts');
+
+        $langFiles = File::glob(resource_path('js/lang/*.ts'));
+        foreach ($langFiles as $file) {
+            if (File::exists($file)) {
+                $this->savedFiles[$file] = File::get($file);
+            }
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore all saved files
+        foreach ($this->savedFiles as $file => $content) {
+            File::put($file, $content);
+        }
+
+        // Delete any test files that didn't exist before
+        if (!isset($this->savedFiles[$this->testTranslationFilePath]) && File::exists($this->testTranslationFilePath)) {
+            File::delete($this->testTranslationFilePath);
+        }
+        if (!isset($this->savedFiles[$this->testTranslationFilePath2]) && File::exists($this->testTranslationFilePath2)) {
+            File::delete($this->testTranslationFilePath2);
+        }
+
+        parent::tearDown();
+    }
+
+    private function createTestTranslationFile(string $content, ?string $filePath = null): void
+    {
+        File::put($filePath ?? $this->testTranslationFilePath, $content);
+    }
+
+    public function testAddsKeyInAlphabeticalOrder()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  cancel: 'Cancel',
+  delete: 'Delete'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:add', [
+            'key' => 'addMeeting',
+            'value' => 'Add Meeting'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // Should be inserted between accountTitle and cancel (with TODO comment for non-English files)
+        $this->assertStringContainsString("addMeeting: 'Add Meeting', // TODO: translate", $updatedContent);
+        $this->assertStringContainsString("accountTitle: 'Account'", $updatedContent);
+        $this->assertStringContainsString("cancel: 'Cancel'", $updatedContent);
+    }
+
+    public function testAddsKeyAtBeginning()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  cancel: 'Cancel',
+  delete: 'Delete'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:add', [
+            'key' => 'accountTitle',
+            'value' => 'Account'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // With TODO comment for non-English files
+        $this->assertStringContainsString("accountTitle: 'Account', // TODO: translate", $updatedContent);
+        $this->assertStringContainsString("cancel: 'Cancel'", $updatedContent);
+        
+        // Verify proper formatting with newline after opening brace
+        $this->assertStringContainsString("{\n  accountTitle:", $updatedContent);
+        $this->assertStringNotContainsString("{ \n  accountTitle:", $updatedContent);
+    }
+
+    public function testAddsKeyAtEnd()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:add', [
+            'key' => 'zipCode',
+            'value' => 'Zip Code'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // With TODO comment for non-English files
+        $this->assertStringContainsString("zipCode: 'Zip Code', // TODO: translate", $updatedContent);
+    }
+
+    public function testAddsKeyToEmptyTranslations()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:add', [
+            'key' => 'accountTitle',
+            'value' => 'Account'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // With TODO comment for non-English files
+        $this->assertStringContainsString("accountTitle: 'Account', // TODO: translate", $updatedContent);
+    }
+
+    public function testEscapesApostrophesInValue()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:add', [
+            'key' => 'confirmMessage',
+            'value' => "Yes, I'm sure"
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        $this->assertStringContainsString("confirmMessage: 'Yes, I\\'m sure'", $updatedContent);
+    }
+
+    public function testRejectsInvalidKeyFormat()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        // Key with underscore
+        $this->artisan('translation:add', [
+            'key' => 'invalid_key',
+            'value' => 'Invalid'
+        ])->assertExitCode(1);
+
+        // Key starting with uppercase
+        $this->artisan('translation:add', [
+            'key' => 'InvalidKey',
+            'value' => 'Invalid'
+        ])->assertExitCode(1);
+
+        // Key with spaces
+        $this->artisan('translation:add', [
+            'key' => 'invalid key',
+            'value' => 'Invalid'
+        ])->assertExitCode(1);
+    }
+
+    public function testAddsToAllLanguageFiles()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+        $this->createTestTranslationFile($content, $this->testTranslationFilePath2);
+
+        $this->artisan('translation:add', [
+            'key' => 'accountTitle',
+            'value' => 'Account'
+        ])->assertExitCode(0);
+
+        $updatedContent1 = File::get($this->testTranslationFilePath);
+        $updatedContent2 = File::get($this->testTranslationFilePath2);
+
+        $this->assertStringContainsString("accountTitle: 'Account'", $updatedContent1);
+        $this->assertStringContainsString("accountTitle: 'Account'", $updatedContent2);
+    }
+
+    public function testAddsToNonEnglishWithTodoComment()
+    {
+        $enContent = <<<'TS'
+export const enTranslations = {
+  cancel: 'Cancel'
+};
+TS;
+
+        $itContent = <<<'TS'
+export const itTranslations = {
+  cancel: 'Annulla'
+};
+TS;
+
+        File::put(resource_path('js/lang/en.ts'), $enContent);
+        File::put(resource_path('js/lang/it.ts'), $itContent);
+
+        $this->artisan('translation:add', [
+            'key' => 'accountTitle',
+            'value' => 'Account'
+        ])->assertExitCode(0);
+
+        $enUpdated = File::get(resource_path('js/lang/en.ts'));
+        $itUpdated = File::get(resource_path('js/lang/it.ts'));
+
+        // English should not have TODO comment
+        $this->assertStringContainsString("accountTitle: 'Account',\n", $enUpdated);
+        $this->assertStringNotContainsString("// TODO: translate", $enUpdated);
+
+        // Italian should have TODO comment
+        $this->assertStringContainsString("accountTitle: 'Account', // TODO: translate", $itUpdated);
+    }
+
+    public function testSkipsExistingKeyWithoutForce()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:add', [
+            'key' => 'accountTitle',
+            'value' => 'New Account'
+        ])
+            ->expectsOutputToContain("Key 'accountTitle' already exists")
+            ->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // Should still have original value
+        $this->assertStringContainsString("accountTitle: 'Account'", $updatedContent);
+        $this->assertStringNotContainsString("New Account", $updatedContent);
+    }
+
+    public function testUpdatesExistingKeyWithForce()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:add', [
+            'key' => 'accountTitle',
+            'value' => 'New Account',
+            '--force' => true
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        $this->assertStringContainsString("accountTitle: 'New Account'", $updatedContent);
+    }
+
+    public function testCaseInsensitiveAlphabeticalOrdering()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  Cancel: 'Cancel',
+  zipCode: 'Zip Code'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:add', [
+            'key' => 'addMeeting',
+            'value' => 'Add Meeting'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // Should be inserted between accountTitle and Cancel (case-insensitive, with TODO comment)
+        $this->assertStringContainsString("addMeeting: 'Add Meeting', // TODO: translate", $updatedContent);
+        $this->assertStringContainsString("accountTitle: 'Account'", $updatedContent);
+        $this->assertStringContainsString("Cancel: 'Cancel'", $updatedContent);
+    }
+}

--- a/src/tests/Feature/DeleteTranslationKeyTest.php
+++ b/src/tests/Feature/DeleteTranslationKeyTest.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class DeleteTranslationKeyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $testTranslationFilePath;
+    private string $testTranslationFilePath2;
+    private array $savedFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testTranslationFilePath = resource_path('js/lang/test.ts');
+        $this->testTranslationFilePath2 = resource_path('js/lang/test2.ts');
+
+        $langFiles = File::glob(resource_path('js/lang/*.ts'));
+        foreach ($langFiles as $file) {
+            if (File::exists($file)) {
+                $this->savedFiles[$file] = File::get($file);
+            }
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore all saved files
+        foreach ($this->savedFiles as $file => $content) {
+            File::put($file, $content);
+        }
+
+        // Delete any test files that didn't exist before
+        if (!isset($this->savedFiles[$this->testTranslationFilePath]) && File::exists($this->testTranslationFilePath)) {
+            File::delete($this->testTranslationFilePath);
+        }
+        if (!isset($this->savedFiles[$this->testTranslationFilePath2]) && File::exists($this->testTranslationFilePath2)) {
+            File::delete($this->testTranslationFilePath2);
+        }
+
+        parent::tearDown();
+    }
+
+    private function createTestTranslationFile(string $content, ?string $filePath = null): void
+    {
+        File::put($filePath ?? $this->testTranslationFilePath, $content);
+    }
+
+    public function testDeletesKeyFromMiddle()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  addMeeting: 'Add Meeting',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:delete', [
+            'key' => 'addMeeting'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        $this->assertStringNotContainsString('addMeeting', $updatedContent);
+        $this->assertStringContainsString('accountTitle', $updatedContent);
+        $this->assertStringContainsString('cancel', $updatedContent);
+    }
+
+    public function testDeletesKeyFromBeginning()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  addMeeting: 'Add Meeting',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:delete', [
+            'key' => 'accountTitle'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        $this->assertStringNotContainsString('accountTitle', $updatedContent);
+        $this->assertStringContainsString('addMeeting', $updatedContent);
+        $this->assertStringContainsString('cancel', $updatedContent);
+    }
+
+    public function testDeletesKeyFromEnd()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  addMeeting: 'Add Meeting',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:delete', [
+            'key' => 'cancel'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        $this->assertStringNotContainsString('cancel', $updatedContent);
+        $this->assertStringContainsString('accountTitle', $updatedContent);
+        $this->assertStringContainsString('addMeeting', $updatedContent);
+    }
+
+    public function testDeletesKeyWithTrailingComment()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  addMeeting: 'Add Meeting', // TODO: translate
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:delete', [
+            'key' => 'addMeeting'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        $this->assertStringNotContainsString('addMeeting', $updatedContent);
+        $this->assertStringNotContainsString('TODO: translate', $updatedContent);
+    }
+
+    public function testDeletesFromAllLanguageFiles()
+    {
+        $content1 = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  cancel: 'Cancel'
+};
+TS;
+
+        $content2 = <<<'TS'
+export const test2Translations = {
+  accountTitle: 'Compte',
+  cancel: 'Annuler'
+};
+TS;
+
+        $this->createTestTranslationFile($content1);
+        $this->createTestTranslationFile($content2, $this->testTranslationFilePath2);
+
+        $this->artisan('translation:delete', [
+            'key' => 'accountTitle'
+        ])->assertExitCode(0);
+
+        $updatedContent1 = File::get($this->testTranslationFilePath);
+        $updatedContent2 = File::get($this->testTranslationFilePath2);
+
+        $this->assertStringNotContainsString('accountTitle', $updatedContent1);
+        $this->assertStringNotContainsString('accountTitle', $updatedContent2);
+    }
+
+    public function testHandlesNonExistentKey()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:delete', [
+            'key' => 'nonExistentKey'
+        ])
+            ->expectsOutputToContain("Key 'nonExistentKey' not found")
+            ->assertExitCode(0);
+
+        // Original content should be unchanged
+        $updatedContent = File::get($this->testTranslationFilePath);
+        $this->assertStringContainsString('accountTitle', $updatedContent);
+        $this->assertStringContainsString('cancel', $updatedContent);
+    }
+
+    public function testPreservesCommasCorrectly()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  addMeeting: 'Add Meeting',
+  cancel: 'Cancel',
+  delete: 'Delete'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:delete', [
+            'key' => 'addMeeting'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // Verify proper comma structure remains
+        $this->assertStringContainsString("accountTitle: 'Account',", $updatedContent);
+        $this->assertStringContainsString("cancel: 'Cancel',", $updatedContent);
+        $this->assertStringContainsString("delete: 'Delete'", $updatedContent);
+    }
+
+    public function testDeletesOnlyKey()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:delete', [
+            'key' => 'accountTitle'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // Should have empty object (but not necessarily with newline)
+        $this->assertMatchesRegularExpression('/\{\s*\}/', $updatedContent);
+        $this->assertStringNotContainsString('accountTitle', $updatedContent);
+    }
+
+    public function testPreservesFileStructure()
+    {
+        $content = <<<'TS'
+import type { LocaleObject } from 'yup';
+
+export const testYupLocale: LocaleObject = {};
+
+/*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
+export const testTranslations = {
+  accountTitle: 'Account',
+  addMeeting: 'Add Meeting',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:delete', [
+            'key' => 'addMeeting'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // Should preserve imports and other exports
+        $this->assertStringContainsString("import type { LocaleObject } from 'yup';", $updatedContent);
+        $this->assertStringContainsString('export const testYupLocale', $updatedContent);
+        $this->assertStringContainsString('/*eslint sort-keys:', $updatedContent);
+
+        // But not the deleted key
+        $this->assertStringNotContainsString('addMeeting', $updatedContent);
+    }
+
+    public function testDeletesFromMultipleFiles()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+        $this->createTestTranslationFile($content, $this->testTranslationFilePath2);
+
+        $this->artisan('translation:delete', [
+            'key' => 'accountTitle'
+        ])->assertExitCode(0);
+
+        // Verify the key was deleted by checking file content immediately
+        $updatedContent1 = File::get($this->testTranslationFilePath);
+        $updatedContent2 = File::get($this->testTranslationFilePath2);
+
+        $this->assertStringNotContainsString('accountTitle', $updatedContent1);
+        $this->assertStringNotContainsString('accountTitle', $updatedContent2);
+        $this->assertStringContainsString('cancel', $updatedContent1);
+        $this->assertStringContainsString('cancel', $updatedContent2);
+    }
+
+    public function testDeletesKeyWithApostrophe()
+    {
+        $content = <<<'TS'
+export const testTranslations = {
+  accountTitle: 'Account',
+  confirmMessage: 'Yes, I\'m sure',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($content);
+
+        $this->artisan('translation:delete', [
+            'key' => 'confirmMessage'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        $this->assertStringNotContainsString('confirmMessage', $updatedContent);
+        $this->assertStringContainsString('accountTitle', $updatedContent);
+        $this->assertStringContainsString('cancel', $updatedContent);
+    }
+}

--- a/src/tests/Feature/UpdateTranslationsFromSpreadsheetTest.php
+++ b/src/tests/Feature/UpdateTranslationsFromSpreadsheetTest.php
@@ -1,0 +1,351 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Tests\TestCase;
+
+class UpdateTranslationsFromSpreadsheetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $testSpreadsheetPath;
+    private string $testTranslationFilePath;
+    private string $originalTranslationContent;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $testDir = storage_path('framework/testing');
+        if (!File::exists($testDir)) {
+            File::makeDirectory($testDir, 0755, true);
+        }
+
+        $this->testSpreadsheetPath = $testDir . '/test-translations.xlsx';
+        $this->testTranslationFilePath = resource_path('js/lang/test.ts');
+
+        if (File::exists($this->testTranslationFilePath)) {
+            $this->originalTranslationContent = File::get($this->testTranslationFilePath);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (File::exists($this->testSpreadsheetPath)) {
+            File::delete($this->testSpreadsheetPath);
+        }
+
+        if (isset($this->originalTranslationContent)) {
+            File::put($this->testTranslationFilePath, $this->originalTranslationContent);
+        } elseif (File::exists($this->testTranslationFilePath)) {
+            File::delete($this->testTranslationFilePath);
+        }
+
+        $backups = File::glob(resource_path('js/lang/*.backup.*'));
+        foreach ($backups as $backup) {
+            File::delete($backup);
+        }
+
+        parent::tearDown();
+    }
+
+    private function createTestSpreadsheet(array $translations): void
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        $sheet->setCellValue('A1', 'Key');
+        $sheet->setCellValue('B1', 'English');
+        $sheet->setCellValue('C1', 'Test Language');
+
+        $row = 2;
+        foreach ($translations as $key => $value) {
+            $sheet->setCellValue("A{$row}", $key);
+            $sheet->setCellValue("B{$row}", "English: {$key}");
+            $sheet->setCellValue("C{$row}", $value);
+            $row++;
+        }
+
+        $writer = new Xlsx($spreadsheet);
+        $writer->save($this->testSpreadsheetPath);
+    }
+
+    private function createTestTranslationFile(string $content): void
+    {
+        File::put($this->testTranslationFilePath, $content);
+    }
+
+    public function testUpdatesTranslationsWithSingleQuotes()
+    {
+        $translationContent = <<<'TS'
+import type { LocaleObject } from 'yup';
+
+export const testYupLocale: LocaleObject = {};
+
+/*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
+export const testTranslations = {
+  accountTitle: 'Account',
+  addMeeting: 'Add Meeting',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($translationContent);
+        $this->createTestSpreadsheet([
+            'accountTitle' => 'Conto',
+            'addMeeting' => 'Aggiungi Riunione',
+            'cancel' => 'Annulla'
+        ]);
+
+        $this->artisan('translation:update-from-spreadsheet', [
+            'spreadsheet' => $this->testSpreadsheetPath,
+            'language' => 'test'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        $this->assertStringContainsString("accountTitle: 'Conto'", $updatedContent);
+        $this->assertStringContainsString("addMeeting: 'Aggiungi Riunione'", $updatedContent);
+        $this->assertStringContainsString("cancel: 'Annulla'", $updatedContent);
+    }
+
+    public function testUpdatesTranslationsWithDoubleQuotes()
+    {
+        $translationContent = <<<'TS'
+import type { LocaleObject } from 'yup';
+
+export const testYupLocale: LocaleObject = {};
+
+/*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
+export const testTranslations = {
+  accountTitle: 'Account',
+  confirmYesImSure: "Yes, I'm sure.",
+  meetingNote: "It's a test"
+};
+TS;
+
+        $this->createTestTranslationFile($translationContent);
+        $this->createTestSpreadsheet([
+            'accountTitle' => 'Conto',
+            'confirmYesImSure' => "Sì, sono sicuro.",
+            'meetingNote' => "È un test"
+        ]);
+
+        $this->artisan('translation:update-from-spreadsheet', [
+            'spreadsheet' => $this->testSpreadsheetPath,
+            'language' => 'test'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // Should convert double quotes to single quotes with escaped apostrophes
+        $this->assertStringContainsString("accountTitle: 'Conto'", $updatedContent);
+        $this->assertStringContainsString("confirmYesImSure: 'Sì, sono sicuro.'", $updatedContent);
+        $this->assertStringContainsString("meetingNote: 'È un test'", $updatedContent);
+    }
+
+    public function testHandlesApostrophesInTranslations()
+    {
+        $translationContent = <<<'TS'
+import type { LocaleObject } from 'yup';
+
+export const testYupLocale: LocaleObject = {};
+
+/*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
+export const testTranslations = {
+  chooseStartTime: 'Choose start time',
+  userNote: 'User note'
+};
+TS;
+
+        $this->createTestTranslationFile($translationContent);
+        $this->createTestSpreadsheet([
+            'chooseStartTime' => "Scegli l'ora di inizio",
+            'userNote' => "L'utente è attivo"
+        ]);
+
+        $this->artisan('translation:update-from-spreadsheet', [
+            'spreadsheet' => $this->testSpreadsheetPath,
+            'language' => 'test'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // Should escape apostrophes
+        $this->assertStringContainsString("chooseStartTime: 'Scegli l\\'ora di inizio'", $updatedContent);
+        $this->assertStringContainsString("userNote: 'L\\'utente è attivo'", $updatedContent);
+    }
+
+    public function testPreservesCommentsAndTrailingCommas()
+    {
+        $translationContent = <<<'TS'
+import type { LocaleObject } from 'yup';
+
+export const testYupLocale: LocaleObject = {};
+
+/*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
+export const testTranslations = {
+  accountTitle: 'Account', // TODO: translate
+  addMeeting: 'Add Meeting',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($translationContent);
+        $this->createTestSpreadsheet([
+            'accountTitle' => 'Conto',
+            'addMeeting' => 'Aggiungi Riunione'
+        ]);
+
+        $this->artisan('translation:update-from-spreadsheet', [
+            'spreadsheet' => $this->testSpreadsheetPath,
+            'language' => 'test'
+        ])->assertExitCode(0);
+
+        $updatedContent = File::get($this->testTranslationFilePath);
+
+        // Should preserve the TODO comment
+        $this->assertStringContainsString("accountTitle: 'Conto', // TODO: translate", $updatedContent);
+        $this->assertStringContainsString("addMeeting: 'Aggiungi Riunione',", $updatedContent);
+    }
+
+    public function testReportsNotFoundKeys()
+    {
+        $translationContent = <<<'TS'
+import type { LocaleObject } from 'yup';
+
+export const testYupLocale: LocaleObject = {};
+
+/*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
+export const testTranslations = {
+  accountTitle: 'Account',
+  addMeeting: 'Add Meeting'
+};
+TS;
+
+        $this->createTestTranslationFile($translationContent);
+        $this->createTestSpreadsheet([
+            'accountTitle' => 'Conto',
+            'addMeeting' => 'Aggiungi Riunione',
+            'nonExistentKey' => 'Some Value',
+            'anotherMissingKey' => 'Another Value'
+        ]);
+
+        $this->artisan('translation:update-from-spreadsheet', [
+            'spreadsheet' => $this->testSpreadsheetPath,
+            'language' => 'test'
+        ])
+            ->expectsOutputToContain('Keys not found in test.ts:')
+            ->expectsOutputToContain('nonExistentKey')
+            ->expectsOutputToContain('anotherMissingKey')
+            ->assertExitCode(0);
+    }
+
+    public function testCreatesBackupFile()
+    {
+        $translationContent = <<<'TS'
+import type { LocaleObject } from 'yup';
+
+export const testYupLocale: LocaleObject = {};
+
+/*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
+export const testTranslations = {
+  accountTitle: 'Account'
+};
+TS;
+
+        $this->createTestTranslationFile($translationContent);
+        $this->createTestSpreadsheet([
+            'accountTitle' => 'Conto'
+        ]);
+
+        $this->artisan('translation:update-from-spreadsheet', [
+            'spreadsheet' => $this->testSpreadsheetPath,
+            'language' => 'test'
+        ])->assertExitCode(0);
+
+        // Check backup was created
+        $backups = File::glob(resource_path('js/lang/test.ts.backup.*'));
+        $this->assertCount(1, $backups);
+
+        // Backup should contain original content
+        $backupContent = File::get($backups[0]);
+        $this->assertEquals($translationContent, $backupContent);
+    }
+
+    public function testFailsWhenSpreadsheetDoesNotExist()
+    {
+        $this->artisan('translation:update-from-spreadsheet', [
+            'spreadsheet' => '/nonexistent/file.xlsx',
+            'language' => 'test'
+        ])
+            ->expectsOutput('Spreadsheet file not found: /nonexistent/file.xlsx')
+            ->assertExitCode(1);
+    }
+
+    public function testFailsWhenLanguageFileDoesNotExist()
+    {
+        $this->createTestSpreadsheet([
+            'accountTitle' => 'Conto'
+        ]);
+
+        $this->artisan('translation:update-from-spreadsheet', [
+            'spreadsheet' => $this->testSpreadsheetPath,
+            'language' => 'nonexistent'
+        ])
+            ->expectsOutputToContain('Translation file not found')
+            ->assertExitCode(1);
+    }
+
+    public function testShowsCorrectSummary()
+    {
+        $translationContent = <<<'TS'
+import type { LocaleObject } from 'yup';
+
+export const testYupLocale: LocaleObject = {};
+
+/*eslint sort-keys: ["error", "asc", {caseSensitive: false}]*/
+export const testTranslations = {
+  accountTitle: 'Account',
+  addMeeting: 'Add Meeting',
+  cancel: 'Cancel'
+};
+TS;
+
+        $this->createTestTranslationFile($translationContent);
+        $this->createTestSpreadsheet([
+            'accountTitle' => 'Conto',
+            'addMeeting' => 'Aggiungi Riunione',
+            'cancel' => 'Annulla',
+            'missingKey' => 'Missing'
+        ]);
+
+        $this->artisan('translation:update-from-spreadsheet', [
+            'spreadsheet' => $this->testSpreadsheetPath,
+            'language' => 'test'
+        ])
+            ->expectsOutput('   • Keys found in spreadsheet: 4')
+            ->expectsOutput('   • Updated existing keys: 3')
+            ->expectsOutput('   • Keys not found in file: 1')
+            ->assertExitCode(0);
+    }
+
+    public function testPreventsUpdatingEnglishTranslations()
+    {
+        $this->createTestSpreadsheet([
+            'accountTitle' => 'Account'
+        ]);
+
+        $this->artisan('translation:update-from-spreadsheet', [
+            'spreadsheet' => $this->testSpreadsheetPath,
+            'language' => 'en'
+        ])
+            ->expectsOutputToContain('Cannot update English translations from spreadsheet')
+            ->expectsOutputToContain("translation:add")
+            ->assertExitCode(1);
+    }
+}


### PR DESCRIPTION
```
> GITHUB_ACTIONS=true php artisan translation

Available commands for the "translation" namespace:
  translation:add                      Add a translation key/value to all language files in alphabetical order
  translation:delete                   Delete a translation key from all language files
  translation:update-from-spreadsheet  Update translation file from XLSX spreadsheet
```

### artisan translation:add
```php
# Add a new key
php artisan translation:add meetingName "Meeting Name"

# Update an existing key (with --force)
php artisan translation:add cancel "Cancelled" --force
```

### artisan translation:delete
```php
php artisan translation:delete oldKey
```

### artisan translation:update-from-spreadsheet
```php
php artisan translation:update-from-spreadsheet /path/to/italian-translations.xlsx it
```

**Note:** if you try to test this with main, currently you'll need to either have env var set or prefix with `GITHUB_ACTIONS=true`


