### PR TITLE
Fix pagination reset when filtering meetings list

### DIFF
--- a/src/resources/js/components/MeetingsList.svelte
+++ b/src/resources/js/components/MeetingsList.svelte
@@ -243,6 +243,12 @@
     }
   }
 
+  function handleSearchTermChange(value: string) {
+    searchTerm = value;
+    currentPosition = 0;
+    lastEditedMeetingId = null;
+  }
+
   onMount(() => {
     // Restore state from store if it exists
     const storedState = $meetingsState;
@@ -300,7 +306,9 @@
   const isAllDaysSelected = $derived(selectedDays.length === weekdayChoices.length);
 </script>
 
-<TableSearch placeholder={$translations.filter} bind:this={tableSearchRef} hoverable={true} bind:inputValue={searchTerm} classes={tableSearchClasses}>
+<TableSearch placeholder={$translations.filter} bind:this={tableSearchRef} hoverable={true} bind:inputValue={() => searchTerm, handleSearchTermChange} classes={tableSearchClasses}>
+  } classes={tableSearchClasses}
+  >
   {#snippet header()}
     <div class="flex w-full flex-shrink-0 flex-col items-stretch justify-end space-y-2 md:w-auto md:flex-row md:items-center md:space-y-0 md:space-x-3">
       {#if serviceBodies.length > 1}


### PR DESCRIPTION
When filtering the meetings list by typing in the search box, if you were on page 2 or later, the results wouldn't display because filtered matches exist on page 1 but pagination wasn't reset. This fix automatically returns to page 1 when the search term changes.