### PR TITLE
Add semantic API OpenAPI spec and docs UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,8 @@ coverage-serve:  ## Serves HTML Coverage Report
 	python3 -m http.server 8100 --directory src/tests/reports/coverage
 
 .PHONY: generate-api-json
-generate-api-json: ## Generates Open API JSON
-	$(TEST_PREFIX) php artisan l5-swagger:generate
+generate-api-json: ## Generates Open API JSON (admin + semantic docs)
+	$(TEST_PREFIX) php artisan l5-swagger:generate --all
 
 .PHONY: lint
 lint:  ## PHP Lint

--- a/src/app/Http/Controllers/Query/Swagger/Controller.php
+++ b/src/app/Http/Controllers/Query/Swagger/Controller.php
@@ -17,7 +17,6 @@ The semantic interface dispatches all operations from a single endpoint (`/clien
 
 ### Things that do not map cleanly onto OpenAPI
 
-- **PHP array syntax** — repeatable array parameters use trailing `[]` in the name (`weekdays[]=2&weekdays[]=3`).
 - **Sign-as-operator** — many filters (`formats`, `services`, `weekdays`, `venue_types`, `meeting_ids`, `root_server_ids`, `format_ids`) use *positive* values to include and *negative* values to exclude. JSON Schema cannot enforce that semantics; it is documented per parameter.
 - **Cross-parameter constraints** — in aggregator mode `GetSearchResults` requires at least one filter parameter. Invalid combinations typically return an empty array `[]` instead of an HTTP error.
 - **Empty-array errors** — many endpoints return `[]` for invalid input rather than a 4xx response body.

--- a/src/app/Http/Controllers/Query/Swagger/Controller.php
+++ b/src/app/Http/Controllers/Query/Swagger/Controller.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Query\Swagger;
+
+use OpenApi\Attributes as OA;
+
+#[OA\OpenApi(
+    openapi: '3.1.0',
+    security: []
+)]
+#[OA\Info(
+    version: '1.0.0',
+    description: <<<DESC
+OpenAPI description of the BMLT Semantic Interface (the read-only meeting-query API) for the JSON data format.
+
+The semantic interface dispatches all operations from a single endpoint (`/client_interface/json/`) using a `switcher` query parameter. To keep each operation discoverable, this spec models each `switcher` value as a distinct path key with the query string baked in. Tools such as Swagger UI, Redoc, and openapi-generator handle these path keys correctly even though the OpenAPI spec technically expects unique URL paths.
+
+### Things that do not map cleanly onto OpenAPI
+
+- **PHP array syntax** — repeatable array parameters use trailing `[]` in the name (`weekdays[]=2&weekdays[]=3`).
+- **Sign-as-operator** — many filters (`formats`, `services`, `weekdays`, `venue_types`, `meeting_ids`, `root_server_ids`, `format_ids`) use *positive* values to include and *negative* values to exclude. JSON Schema cannot enforce that semantics; it is documented per parameter.
+- **Cross-parameter constraints** — in aggregator mode `GetSearchResults` requires at least one filter parameter. Invalid combinations typically return an empty array `[]` instead of an HTTP error.
+- **Empty-array errors** — many endpoints return `[]` for invalid input rather than a 4xx response body.
+DESC,
+    title: 'BMLT Semantic API'
+)]
+#[OA\Server(
+    url: 'L5_SWAGGER_CONST_HOST',
+    description: 'this server'
+)]
+#[OA\Tag(name: 'Meetings', description: 'Meeting search and change history')]
+#[OA\Tag(name: 'Formats', description: 'Meeting format metadata')]
+#[OA\Tag(name: 'Service Bodies', description: 'Service body (region/area) metadata')]
+#[OA\Tag(name: 'Fields', description: 'Schema introspection')]
+#[OA\Tag(name: 'Server', description: 'Server information and coverage')]
+class Controller
+{
+}

--- a/src/app/Http/Controllers/Query/Swagger/FieldsController.php
+++ b/src/app/Http/Controllers/Query/Swagger/FieldsController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers\Query\Swagger;
+
+use OpenApi\Attributes as OA;
+
+class FieldsController extends Controller
+{
+    #[OA\Get(
+        path: '/client_interface/json/?switcher=GetFieldKeys',
+        operationId: 'getFieldKeys',
+        summary: 'Get all available field keys',
+        tags: ['Fields'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'List of field key descriptors',
+                content: new OA\JsonContent(
+                    type: 'array',
+                    items: new OA\Items(
+                        type: 'object',
+                        properties: [
+                            new OA\Property(property: 'key', type: 'string'),
+                            new OA\Property(property: 'description', type: 'string'),
+                        ]
+                    )
+                )
+            ),
+        ]
+    )]
+    public function getFieldKeys()
+    {
+    }
+
+    #[OA\Get(
+        path: '/client_interface/json/?switcher=GetFieldValues',
+        operationId: 'getFieldValues',
+        summary: 'Get distinct values for a field',
+        tags: ['Fields'],
+        parameters: [
+            new OA\Parameter(name: 'meeting_key', in: 'query', required: true, description: 'Field key whose distinct values should be returned.', schema: new OA\Schema(type: 'string', example: 'location_municipality')),
+            new OA\Parameter(name: 'specific_formats', in: 'query', description: 'Comma-separated list of format IDs to limit the field values to.', schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'all_formats', in: 'query', description: 'Set to `1` to include all formats (not just `specific_formats`).', schema: new OA\Schema(type: 'string', enum: ['0', '1'])),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'List of distinct values with usage counts',
+                content: new OA\JsonContent(
+                    type: 'array',
+                    items: new OA\Items(
+                        type: 'object',
+                        properties: [
+                            new OA\Property(property: 'ids', type: 'string'),
+                            new OA\Property(property: 'meeting_key_value', type: 'string'),
+                        ]
+                    )
+                )
+            ),
+            new OA\Response(response: 400, ref: '#/components/responses/SemBadRequest'),
+        ]
+    )]
+    public function getFieldValues()
+    {
+    }
+}

--- a/src/app/Http/Controllers/Query/Swagger/FormatsController.php
+++ b/src/app/Http/Controllers/Query/Swagger/FormatsController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Query\Swagger;
+
+use OpenApi\Attributes as OA;
+
+class FormatsController extends Controller
+{
+    #[OA\Get(
+        path: '/client_interface/json/?switcher=GetFormats',
+        operationId: 'getSemanticFormats',
+        summary: 'Get meeting formats',
+        tags: ['Formats'],
+        parameters: [
+            new OA\Parameter(ref: '#/components/parameters/SemLangEnum'),
+            new OA\Parameter(ref: '#/components/parameters/SemShowAll'),
+            new OA\Parameter(name: 'format_ids', in: 'query', description: 'Format IDs to include (positive) or exclude (negative). Comma-separated.', schema: new OA\Schema(type: 'string', example: '1,2,-3')),
+            new OA\Parameter(name: 'key_strings', in: 'query', description: 'Format key strings to filter by. Comma-separated.', schema: new OA\Schema(type: 'string', example: 'O,C')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'List of formats',
+                content: new OA\JsonContent(type: 'array', items: new OA\Items(ref: '#/components/schemas/SemanticFormat'))
+            ),
+        ]
+    )]
+    public function getFormats()
+    {
+    }
+}

--- a/src/app/Http/Controllers/Query/Swagger/MeetingsController.php
+++ b/src/app/Http/Controllers/Query/Swagger/MeetingsController.php
@@ -14,16 +14,11 @@ class MeetingsController extends Controller
         tags: ['Meetings'],
         parameters: [
             new OA\Parameter(ref: '#/components/parameters/SemMeetingIds'),
-            new OA\Parameter(ref: '#/components/parameters/SemMeetingIdsArray'),
             new OA\Parameter(ref: '#/components/parameters/SemWeekdays'),
-            new OA\Parameter(ref: '#/components/parameters/SemWeekdaysArray'),
             new OA\Parameter(ref: '#/components/parameters/SemVenueTypes'),
-            new OA\Parameter(ref: '#/components/parameters/SemVenueTypesArray'),
             new OA\Parameter(ref: '#/components/parameters/SemFormats'),
-            new OA\Parameter(ref: '#/components/parameters/SemFormatsArray'),
             new OA\Parameter(ref: '#/components/parameters/SemFormatsComparisonOperator'),
             new OA\Parameter(ref: '#/components/parameters/SemServices'),
-            new OA\Parameter(ref: '#/components/parameters/SemServicesArray'),
             new OA\Parameter(ref: '#/components/parameters/SemRecursive'),
             new OA\Parameter(ref: '#/components/parameters/SemGetUsedFormats'),
             new OA\Parameter(ref: '#/components/parameters/SemGetFormatsOnly'),
@@ -55,7 +50,6 @@ class MeetingsController extends Controller
             new OA\Parameter(ref: '#/components/parameters/SemAdvancedPublished'),
             new OA\Parameter(ref: '#/components/parameters/SemLangEnum'),
             new OA\Parameter(ref: '#/components/parameters/SemRootServerIds'),
-            new OA\Parameter(ref: '#/components/parameters/SemRootServerIdsArray'),
         ],
         responses: [
             new OA\Response(

--- a/src/app/Http/Controllers/Query/Swagger/MeetingsController.php
+++ b/src/app/Http/Controllers/Query/Swagger/MeetingsController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers\Query\Swagger;
+
+use OpenApi\Attributes as OA;
+
+class MeetingsController extends Controller
+{
+    #[OA\Get(
+        path: '/client_interface/json/?switcher=GetSearchResults',
+        operationId: 'getSearchResults',
+        summary: 'Search for meetings',
+        description: 'Search meetings with extensive filtering (location, day, time, format, service body, text). In aggregator mode at least one filter parameter is required, otherwise the response will be an empty array.',
+        tags: ['Meetings'],
+        parameters: [
+            new OA\Parameter(ref: '#/components/parameters/SemMeetingIds'),
+            new OA\Parameter(ref: '#/components/parameters/SemMeetingIdsArray'),
+            new OA\Parameter(ref: '#/components/parameters/SemWeekdays'),
+            new OA\Parameter(ref: '#/components/parameters/SemWeekdaysArray'),
+            new OA\Parameter(ref: '#/components/parameters/SemVenueTypes'),
+            new OA\Parameter(ref: '#/components/parameters/SemVenueTypesArray'),
+            new OA\Parameter(ref: '#/components/parameters/SemFormats'),
+            new OA\Parameter(ref: '#/components/parameters/SemFormatsArray'),
+            new OA\Parameter(ref: '#/components/parameters/SemFormatsComparisonOperator'),
+            new OA\Parameter(ref: '#/components/parameters/SemServices'),
+            new OA\Parameter(ref: '#/components/parameters/SemServicesArray'),
+            new OA\Parameter(ref: '#/components/parameters/SemRecursive'),
+            new OA\Parameter(ref: '#/components/parameters/SemGetUsedFormats'),
+            new OA\Parameter(ref: '#/components/parameters/SemGetFormatsOnly'),
+            new OA\Parameter(ref: '#/components/parameters/SemSearchString'),
+            new OA\Parameter(ref: '#/components/parameters/SemStringSearchIsAnAddress'),
+            new OA\Parameter(ref: '#/components/parameters/SemSearchStringRadius'),
+            new OA\Parameter(ref: '#/components/parameters/SemStartsAfterH'),
+            new OA\Parameter(ref: '#/components/parameters/SemStartsAfterM'),
+            new OA\Parameter(ref: '#/components/parameters/SemStartsBeforeH'),
+            new OA\Parameter(ref: '#/components/parameters/SemStartsBeforeM'),
+            new OA\Parameter(ref: '#/components/parameters/SemEndsBeforeH'),
+            new OA\Parameter(ref: '#/components/parameters/SemEndsBeforeM'),
+            new OA\Parameter(ref: '#/components/parameters/SemMinDurationH'),
+            new OA\Parameter(ref: '#/components/parameters/SemMinDurationM'),
+            new OA\Parameter(ref: '#/components/parameters/SemMaxDurationH'),
+            new OA\Parameter(ref: '#/components/parameters/SemMaxDurationM'),
+            new OA\Parameter(ref: '#/components/parameters/SemLatVal'),
+            new OA\Parameter(ref: '#/components/parameters/SemLongVal'),
+            new OA\Parameter(ref: '#/components/parameters/SemGeoWidth'),
+            new OA\Parameter(ref: '#/components/parameters/SemGeoWidthKm'),
+            new OA\Parameter(ref: '#/components/parameters/SemSortResultsByDistance'),
+            new OA\Parameter(ref: '#/components/parameters/SemMeetingKeyFilter'),
+            new OA\Parameter(ref: '#/components/parameters/SemMeetingKeyValue'),
+            new OA\Parameter(ref: '#/components/parameters/SemDataFieldKey'),
+            new OA\Parameter(ref: '#/components/parameters/SemSortKeys'),
+            new OA\Parameter(ref: '#/components/parameters/SemSortKey'),
+            new OA\Parameter(ref: '#/components/parameters/SemPageSize'),
+            new OA\Parameter(ref: '#/components/parameters/SemPageNum'),
+            new OA\Parameter(ref: '#/components/parameters/SemAdvancedPublished'),
+            new OA\Parameter(ref: '#/components/parameters/SemLangEnum'),
+            new OA\Parameter(ref: '#/components/parameters/SemRootServerIds'),
+            new OA\Parameter(ref: '#/components/parameters/SemRootServerIdsArray'),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Meeting search results. May be a bare array of meetings, an array of formats when `get_formats_only=1`, or a `{meetings, formats}` envelope when `get_used_formats=1`.',
+                content: new OA\JsonContent(
+                    oneOf: [
+                        new OA\Schema(type: 'array', items: new OA\Items(ref: '#/components/schemas/SemanticMeeting')),
+                        new OA\Schema(type: 'array', items: new OA\Items(ref: '#/components/schemas/SemanticFormat')),
+                        new OA\Schema(
+                            type: 'object',
+                            properties: [
+                                new OA\Property(property: 'meetings', type: 'array', items: new OA\Items(ref: '#/components/schemas/SemanticMeeting')),
+                                new OA\Property(property: 'formats', type: 'array', items: new OA\Items(ref: '#/components/schemas/SemanticFormat')),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OA\Response(response: 400, ref: '#/components/responses/SemBadRequest'),
+            new OA\Response(response: 500, ref: '#/components/responses/SemServerError'),
+        ]
+    )]
+    public function getSearchResults()
+    {
+    }
+
+    #[OA\Get(
+        path: '/client_interface/json/?switcher=GetChanges',
+        operationId: 'getChanges',
+        summary: 'Get meeting changes within a date range',
+        tags: ['Meetings'],
+        parameters: [
+            new OA\Parameter(name: 'start_date', in: 'query', description: 'Start date (inclusive) in YYYY-MM-DD format.', schema: new OA\Schema(type: 'string', format: 'date')),
+            new OA\Parameter(name: 'end_date', in: 'query', description: 'End date (inclusive) in YYYY-MM-DD format.', schema: new OA\Schema(type: 'string', format: 'date')),
+            new OA\Parameter(name: 'meeting_id', in: 'query', description: 'Restrict to changes for a single meeting.', schema: new OA\Schema(type: 'integer')),
+            new OA\Parameter(name: 'service_body_id', in: 'query', description: 'Restrict to changes within a single service body.', schema: new OA\Schema(type: 'integer')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'List of meeting changes',
+                content: new OA\JsonContent(type: 'array', items: new OA\Items(ref: '#/components/schemas/SemanticMeetingChange'))
+            ),
+        ]
+    )]
+    public function getChanges()
+    {
+    }
+}

--- a/src/app/Http/Controllers/Query/Swagger/Parameters.php
+++ b/src/app/Http/Controllers/Query/Swagger/Parameters.php
@@ -5,16 +5,11 @@ namespace App\Http\Controllers\Query\Swagger;
 use OpenApi\Attributes as OA;
 
 #[OA\Parameter(parameter: 'SemMeetingIds', name: 'meeting_ids', in: 'query', description: 'Comma-separated meeting IDs. Positive values include, negative values exclude (e.g. `123,456,-789`).', schema: new OA\Schema(type: 'string'))]
-#[OA\Parameter(parameter: 'SemMeetingIdsArray', name: 'meeting_ids[]', in: 'query', description: 'Repeatable form of `meeting_ids`. Positive includes, negative excludes.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer')))]
 #[OA\Parameter(parameter: 'SemWeekdays', name: 'weekdays', in: 'query', description: 'Days of week as comma-separated values. 1=Sunday … 7=Saturday. Negative values exclude.', schema: new OA\Schema(type: 'string', example: '2,3,4'))]
-#[OA\Parameter(parameter: 'SemWeekdaysArray', name: 'weekdays[]', in: 'query', description: 'Repeatable form of `weekdays`. 1=Sunday … 7=Saturday. Negative values exclude.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer', minimum: -7, maximum: 7)))]
 #[OA\Parameter(parameter: 'SemVenueTypes', name: 'venue_types', in: 'query', description: 'Venue type filter, comma-separated. 1=In-person, 2=Virtual, 3=Hybrid. Negative values exclude.', schema: new OA\Schema(type: 'string'))]
-#[OA\Parameter(parameter: 'SemVenueTypesArray', name: 'venue_types[]', in: 'query', description: 'Repeatable form of `venue_types`. Negative values exclude.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer', enum: [-3, -2, -1, 1, 2, 3])))]
 #[OA\Parameter(parameter: 'SemFormats', name: 'formats', in: 'query', description: 'Format IDs as comma-separated values. Positive includes, negative excludes.', schema: new OA\Schema(type: 'string'))]
-#[OA\Parameter(parameter: 'SemFormatsArray', name: 'formats[]', in: 'query', description: 'Repeatable form of `formats`. Positive includes, negative excludes.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer')))]
 #[OA\Parameter(parameter: 'SemFormatsComparisonOperator', name: 'formats_comparison_operator', in: 'query', description: 'Logical operator for combining multiple `formats` values. Defaults to AND.', schema: new OA\Schema(type: 'string', enum: ['AND', 'OR'], default: 'AND'))]
 #[OA\Parameter(parameter: 'SemServices', name: 'services', in: 'query', description: 'Service body IDs as comma-separated values. Positive includes, negative excludes.', schema: new OA\Schema(type: 'string'))]
-#[OA\Parameter(parameter: 'SemServicesArray', name: 'services[]', in: 'query', description: 'Repeatable form of `services`. Positive includes, negative excludes.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer')))]
 #[OA\Parameter(parameter: 'SemRecursive', name: 'recursive', in: 'query', description: 'Set to `1` to include child service bodies when filtering by `services`.', schema: new OA\Schema(type: 'string', enum: ['0', '1']))]
 #[OA\Parameter(parameter: 'SemGetUsedFormats', name: 'get_used_formats', in: 'query', description: 'Set to `1` to also return the formats used by the matched meetings (alters response shape to `{meetings, formats}`).', schema: new OA\Schema(type: 'string', enum: ['0', '1']))]
 #[OA\Parameter(parameter: 'SemGetFormatsOnly', name: 'get_formats_only', in: 'query', description: 'Set to `1` to return only the formats and omit the meetings (requires `get_used_formats=1`).', schema: new OA\Schema(type: 'string', enum: ['0', '1']))]
@@ -47,7 +42,6 @@ use OpenApi\Attributes as OA;
 #[OA\Parameter(parameter: 'SemLangEnum', name: 'lang_enum', in: 'query', description: 'Language code for translated format names (en, de, fr, es, it, pl, pt, sv, dk, fa).', schema: new OA\Schema(type: 'string'))]
 #[OA\Parameter(parameter: 'SemShowAll', name: 'show_all', in: 'query', description: 'Set to `1` to include all formats (including ones not currently used by any meeting).', schema: new OA\Schema(type: 'string', enum: ['0', '1']))]
 #[OA\Parameter(parameter: 'SemRootServerIds', name: 'root_server_ids', in: 'query', description: 'Aggregator mode only. Comma-separated root server IDs. Positive includes, negative excludes.', schema: new OA\Schema(type: 'string'))]
-#[OA\Parameter(parameter: 'SemRootServerIdsArray', name: 'root_server_ids[]', in: 'query', description: 'Aggregator mode only. Repeatable form of `root_server_ids`. Positive includes, negative excludes.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer')))]
 #[OA\Response(
     response: 'SemBadRequest',
     description: 'Bad request — usually a missing required parameter.',

--- a/src/app/Http/Controllers/Query/Swagger/Parameters.php
+++ b/src/app/Http/Controllers/Query/Swagger/Parameters.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers\Query\Swagger;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Parameter(parameter: 'SemMeetingIds', name: 'meeting_ids', in: 'query', description: 'Comma-separated meeting IDs. Positive values include, negative values exclude (e.g. `123,456,-789`).', schema: new OA\Schema(type: 'string'))]
+#[OA\Parameter(parameter: 'SemMeetingIdsArray', name: 'meeting_ids[]', in: 'query', description: 'Repeatable form of `meeting_ids`. Positive includes, negative excludes.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer')))]
+#[OA\Parameter(parameter: 'SemWeekdays', name: 'weekdays', in: 'query', description: 'Days of week as comma-separated values. 1=Sunday … 7=Saturday. Negative values exclude.', schema: new OA\Schema(type: 'string', example: '2,3,4'))]
+#[OA\Parameter(parameter: 'SemWeekdaysArray', name: 'weekdays[]', in: 'query', description: 'Repeatable form of `weekdays`. 1=Sunday … 7=Saturday. Negative values exclude.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer', minimum: -7, maximum: 7)))]
+#[OA\Parameter(parameter: 'SemVenueTypes', name: 'venue_types', in: 'query', description: 'Venue type filter, comma-separated. 1=In-person, 2=Virtual, 3=Hybrid. Negative values exclude.', schema: new OA\Schema(type: 'string'))]
+#[OA\Parameter(parameter: 'SemVenueTypesArray', name: 'venue_types[]', in: 'query', description: 'Repeatable form of `venue_types`. Negative values exclude.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer', enum: [-3, -2, -1, 1, 2, 3])))]
+#[OA\Parameter(parameter: 'SemFormats', name: 'formats', in: 'query', description: 'Format IDs as comma-separated values. Positive includes, negative excludes.', schema: new OA\Schema(type: 'string'))]
+#[OA\Parameter(parameter: 'SemFormatsArray', name: 'formats[]', in: 'query', description: 'Repeatable form of `formats`. Positive includes, negative excludes.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer')))]
+#[OA\Parameter(parameter: 'SemFormatsComparisonOperator', name: 'formats_comparison_operator', in: 'query', description: 'Logical operator for combining multiple `formats` values. Defaults to AND.', schema: new OA\Schema(type: 'string', enum: ['AND', 'OR'], default: 'AND'))]
+#[OA\Parameter(parameter: 'SemServices', name: 'services', in: 'query', description: 'Service body IDs as comma-separated values. Positive includes, negative excludes.', schema: new OA\Schema(type: 'string'))]
+#[OA\Parameter(parameter: 'SemServicesArray', name: 'services[]', in: 'query', description: 'Repeatable form of `services`. Positive includes, negative excludes.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer')))]
+#[OA\Parameter(parameter: 'SemRecursive', name: 'recursive', in: 'query', description: 'Set to `1` to include child service bodies when filtering by `services`.', schema: new OA\Schema(type: 'string', enum: ['0', '1']))]
+#[OA\Parameter(parameter: 'SemGetUsedFormats', name: 'get_used_formats', in: 'query', description: 'Set to `1` to also return the formats used by the matched meetings (alters response shape to `{meetings, formats}`).', schema: new OA\Schema(type: 'string', enum: ['0', '1']))]
+#[OA\Parameter(parameter: 'SemGetFormatsOnly', name: 'get_formats_only', in: 'query', description: 'Set to `1` to return only the formats and omit the meetings (requires `get_used_formats=1`).', schema: new OA\Schema(type: 'string', enum: ['0', '1']))]
+#[OA\Parameter(parameter: 'SemSearchString', name: 'SearchString', in: 'query', description: 'Free-text search string. URL-encode the value.', schema: new OA\Schema(type: 'string'))]
+#[OA\Parameter(parameter: 'SemStringSearchIsAnAddress', name: 'StringSearchIsAnAddress', in: 'query', description: 'Set to `1` to interpret `SearchString` as an address to geocode. Requires a Google API key on the server.', schema: new OA\Schema(type: 'string', enum: ['0', '1']))]
+#[OA\Parameter(parameter: 'SemSearchStringRadius', name: 'SearchStringRadius', in: 'query', description: 'Radius for address searches. Positive = distance (miles or km depending on server). Negative integer = auto-radius.', schema: new OA\Schema(type: 'number'))]
+#[OA\Parameter(parameter: 'SemStartsAfterH', name: 'StartsAfterH', in: 'query', description: 'Earliest start hour (0–23).', schema: new OA\Schema(type: 'integer', minimum: 0, maximum: 23))]
+#[OA\Parameter(parameter: 'SemStartsAfterM', name: 'StartsAfterM', in: 'query', description: 'Earliest start minute (0–59).', schema: new OA\Schema(type: 'integer', minimum: 0, maximum: 59))]
+#[OA\Parameter(parameter: 'SemStartsBeforeH', name: 'StartsBeforeH', in: 'query', description: 'Latest start hour (0–23).', schema: new OA\Schema(type: 'integer', minimum: 0, maximum: 23))]
+#[OA\Parameter(parameter: 'SemStartsBeforeM', name: 'StartsBeforeM', in: 'query', description: 'Latest start minute (0–59).', schema: new OA\Schema(type: 'integer', minimum: 0, maximum: 59))]
+#[OA\Parameter(parameter: 'SemEndsBeforeH', name: 'EndsBeforeH', in: 'query', description: 'Latest end hour (0–23).', schema: new OA\Schema(type: 'integer', minimum: 0, maximum: 23))]
+#[OA\Parameter(parameter: 'SemEndsBeforeM', name: 'EndsBeforeM', in: 'query', description: 'Latest end minute (0–59).', schema: new OA\Schema(type: 'integer', minimum: 0, maximum: 59))]
+#[OA\Parameter(parameter: 'SemMinDurationH', name: 'MinDurationH', in: 'query', description: 'Minimum duration, hours portion.', schema: new OA\Schema(type: 'integer', minimum: 0))]
+#[OA\Parameter(parameter: 'SemMinDurationM', name: 'MinDurationM', in: 'query', description: 'Minimum duration, minutes portion (0–59).', schema: new OA\Schema(type: 'integer', minimum: 0, maximum: 59))]
+#[OA\Parameter(parameter: 'SemMaxDurationH', name: 'MaxDurationH', in: 'query', description: 'Maximum duration, hours portion.', schema: new OA\Schema(type: 'integer', minimum: 0))]
+#[OA\Parameter(parameter: 'SemMaxDurationM', name: 'MaxDurationM', in: 'query', description: 'Maximum duration, minutes portion (0–59).', schema: new OA\Schema(type: 'integer', minimum: 0, maximum: 59))]
+#[OA\Parameter(parameter: 'SemLatVal', name: 'lat_val', in: 'query', description: 'Latitude for geographic search.', schema: new OA\Schema(type: 'number', format: 'float', minimum: -90, maximum: 90))]
+#[OA\Parameter(parameter: 'SemLongVal', name: 'long_val', in: 'query', description: 'Longitude for geographic search.', schema: new OA\Schema(type: 'number', format: 'float', minimum: -180, maximum: 180))]
+#[OA\Parameter(parameter: 'SemGeoWidth', name: 'geo_width', in: 'query', description: 'Search radius in miles. Negative integer = auto-radius.', schema: new OA\Schema(type: 'number'))]
+#[OA\Parameter(parameter: 'SemGeoWidthKm', name: 'geo_width_km', in: 'query', description: 'Search radius in kilometers. Negative integer = auto-radius.', schema: new OA\Schema(type: 'number'))]
+#[OA\Parameter(parameter: 'SemSortResultsByDistance', name: 'sort_results_by_distance', in: 'query', description: 'Set to `1` to sort results by distance from `lat_val`/`long_val`.', schema: new OA\Schema(type: 'string', enum: ['0', '1']))]
+#[OA\Parameter(parameter: 'SemMeetingKeyFilter', name: 'meeting_key', in: 'query', description: 'Field key to filter on (used with `meeting_key_value`).', schema: new OA\Schema(type: 'string'))]
+#[OA\Parameter(parameter: 'SemMeetingKeyValue', name: 'meeting_key_value', in: 'query', description: 'Value to match against the field named by `meeting_key`.', schema: new OA\Schema(type: 'string'))]
+#[OA\Parameter(parameter: 'SemDataFieldKey', name: 'data_field_key', in: 'query', description: 'Comma-separated list of fields to include in each returned meeting (whitelist).', schema: new OA\Schema(type: 'string', example: 'id_bigint,meeting_name,weekday_tinyint,start_time'))]
+#[OA\Parameter(parameter: 'SemSortKeys', name: 'sort_keys', in: 'query', description: 'Comma-separated list of fields to sort by.', schema: new OA\Schema(type: 'string'))]
+#[OA\Parameter(parameter: 'SemSortKey', name: 'sort_key', in: 'query', description: 'Predefined sort alias.', schema: new OA\Schema(type: 'string', enum: ['weekday', 'time', 'town', 'state', 'weekday_state']))]
+#[OA\Parameter(parameter: 'SemPageSize', name: 'page_size', in: 'query', description: 'Number of results per page.', schema: new OA\Schema(type: 'integer', minimum: 1))]
+#[OA\Parameter(parameter: 'SemPageNum', name: 'page_num', in: 'query', description: 'Page number, 1-based. Only meaningful when `page_size` is set.', schema: new OA\Schema(type: 'integer', minimum: 1, default: 1))]
+#[OA\Parameter(parameter: 'SemAdvancedPublished', name: 'advanced_published', in: 'query', description: 'Published-status filter. Omit to return only published meetings. `0` returns both. `-1` returns only unpublished (requires authentication).', schema: new OA\Schema(type: 'integer', enum: [-1, 0]))]
+#[OA\Parameter(parameter: 'SemLangEnum', name: 'lang_enum', in: 'query', description: 'Language code for translated format names (en, de, fr, es, it, pl, pt, sv, dk, fa).', schema: new OA\Schema(type: 'string'))]
+#[OA\Parameter(parameter: 'SemShowAll', name: 'show_all', in: 'query', description: 'Set to `1` to include all formats (including ones not currently used by any meeting).', schema: new OA\Schema(type: 'string', enum: ['0', '1']))]
+#[OA\Parameter(parameter: 'SemRootServerIds', name: 'root_server_ids', in: 'query', description: 'Aggregator mode only. Comma-separated root server IDs. Positive includes, negative excludes.', schema: new OA\Schema(type: 'string'))]
+#[OA\Parameter(parameter: 'SemRootServerIdsArray', name: 'root_server_ids[]', in: 'query', description: 'Aggregator mode only. Repeatable form of `root_server_ids`. Positive includes, negative excludes.', style: 'form', explode: true, schema: new OA\Schema(type: 'array', items: new OA\Items(type: 'integer')))]
+#[OA\Response(
+    response: 'SemBadRequest',
+    description: 'Bad request — usually a missing required parameter.',
+    content: new OA\JsonContent(ref: '#/components/schemas/SemanticError')
+)]
+#[OA\Response(
+    response: 'SemServerError',
+    description: 'Internal server error — for example, a geocoding failure when `StringSearchIsAnAddress=1`.',
+    content: new OA\JsonContent(ref: '#/components/schemas/SemanticError')
+)]
+class Parameters extends Controller
+{
+}

--- a/src/app/Http/Controllers/Query/Swagger/Schemas.php
+++ b/src/app/Http/Controllers/Query/Swagger/Schemas.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Http\Controllers\Query\Swagger;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'SemanticMeeting',
+    type: 'object',
+    description: "A meeting record. The actual field set depends on the server's enabled fields and the `data_field_key` parameter.",
+    additionalProperties: true,
+    properties: [
+        new OA\Property(property: 'id_bigint', type: 'string', description: 'Numeric meeting ID, returned as a string.'),
+        new OA\Property(property: 'worldid_mixed', type: 'string', description: 'NAWS world committee code.'),
+        new OA\Property(property: 'shared_group_id_bigint', type: 'string'),
+        new OA\Property(property: 'service_body_bigint', type: 'string'),
+        new OA\Property(property: 'weekday_tinyint', type: 'string', description: '1=Sunday … 7=Saturday.'),
+        new OA\Property(property: 'venue_type', type: 'string', description: '1=In-person, 2=Virtual, 3=Hybrid.'),
+        new OA\Property(property: 'start_time', type: 'string', description: 'Local start time, HH:MM:SS.'),
+        new OA\Property(property: 'duration_time', type: 'string', description: 'Duration, HH:MM:SS.'),
+        new OA\Property(property: 'time_zone', type: 'string'),
+        new OA\Property(property: 'formats', type: 'string', description: 'Comma-separated format key strings.'),
+        new OA\Property(property: 'lang_enum', type: 'string'),
+        new OA\Property(property: 'longitude', type: 'string'),
+        new OA\Property(property: 'latitude', type: 'string'),
+        new OA\Property(property: 'distance_in_km', type: 'string', description: 'Present only when sorting by distance.'),
+        new OA\Property(property: 'distance_in_miles', type: 'string', description: 'Present only when sorting by distance.'),
+        new OA\Property(property: 'meeting_name', type: 'string'),
+        new OA\Property(property: 'location_text', type: 'string'),
+        new OA\Property(property: 'location_info', type: 'string'),
+        new OA\Property(property: 'location_street', type: 'string'),
+        new OA\Property(property: 'location_city_subsection', type: 'string'),
+        new OA\Property(property: 'location_neighborhood', type: 'string'),
+        new OA\Property(property: 'location_municipality', type: 'string'),
+        new OA\Property(property: 'location_sub_province', type: 'string'),
+        new OA\Property(property: 'location_province', type: 'string'),
+        new OA\Property(property: 'location_postal_code_1', type: 'string'),
+        new OA\Property(property: 'location_nation', type: 'string'),
+        new OA\Property(property: 'comments', type: 'string'),
+        new OA\Property(property: 'train_lines', type: 'string'),
+        new OA\Property(property: 'bus_lines', type: 'string'),
+        new OA\Property(property: 'phone_meeting_number', type: 'string'),
+        new OA\Property(property: 'virtual_meeting_link', type: 'string'),
+        new OA\Property(property: 'virtual_meeting_additional_info', type: 'string'),
+        new OA\Property(property: 'contact_name_1', type: 'string'),
+        new OA\Property(property: 'contact_phone_1', type: 'string'),
+        new OA\Property(property: 'contact_email_1', type: 'string'),
+        new OA\Property(property: 'root_server_id', type: 'string', description: 'Aggregator mode only — ID of the root server this meeting came from.'),
+        new OA\Property(property: 'root_server_uri', type: 'string'),
+        new OA\Property(property: 'format_shared_id_list', type: 'string'),
+    ]
+)]
+#[OA\Schema(
+    schema: 'SemanticFormat',
+    type: 'object',
+    additionalProperties: true,
+    properties: [
+        new OA\Property(property: 'key_string', type: 'string'),
+        new OA\Property(property: 'name_string', type: 'string'),
+        new OA\Property(property: 'description_string', type: 'string'),
+        new OA\Property(property: 'lang', type: 'string'),
+        new OA\Property(property: 'id', type: 'string'),
+        new OA\Property(property: 'world_id', type: 'string'),
+        new OA\Property(property: 'root_server_id', type: 'string', description: 'Aggregator mode only.'),
+        new OA\Property(property: 'root_server_uri', type: 'string', description: 'Aggregator mode only.'),
+        new OA\Property(property: 'format_type_enum', type: 'string'),
+    ]
+)]
+#[OA\Schema(
+    schema: 'SemanticServiceBody',
+    type: 'object',
+    additionalProperties: true,
+    properties: [
+        new OA\Property(property: 'id', type: 'string'),
+        new OA\Property(property: 'parent_id', type: 'string'),
+        new OA\Property(property: 'name', type: 'string'),
+        new OA\Property(property: 'description', type: 'string'),
+        new OA\Property(property: 'type', type: 'string'),
+        new OA\Property(property: 'url', type: 'string'),
+        new OA\Property(property: 'helpline', type: 'string'),
+        new OA\Property(property: 'world_id', type: 'string'),
+        new OA\Property(property: 'root_server_id', type: 'string', description: 'Aggregator mode only.'),
+        new OA\Property(property: 'root_server_uri', type: 'string', description: 'Aggregator mode only.'),
+    ]
+)]
+#[OA\Schema(
+    schema: 'SemanticMeetingChange',
+    type: 'object',
+    additionalProperties: true,
+    properties: [
+        new OA\Property(property: 'date_int', type: 'string', description: 'Unix timestamp of the change.'),
+        new OA\Property(property: 'date_string', type: 'string'),
+        new OA\Property(property: 'change_type', type: 'string', description: 'e.g. comdef_change_type_change, comdef_change_type_new, comdef_change_type_delete.'),
+        new OA\Property(property: 'meeting_id', type: 'string'),
+        new OA\Property(property: 'meeting_name', type: 'string'),
+        new OA\Property(property: 'user_id', type: 'string'),
+        new OA\Property(property: 'user_name', type: 'string'),
+        new OA\Property(property: 'service_body_id', type: 'string'),
+        new OA\Property(property: 'service_body_name', type: 'string'),
+        new OA\Property(property: 'details', type: 'object', additionalProperties: true, description: 'Per-field before/after values for change events.'),
+    ]
+)]
+#[OA\Schema(
+    schema: 'SemanticServerInfo',
+    type: 'object',
+    additionalProperties: true,
+    properties: [
+        new OA\Property(property: 'version', type: 'string'),
+        new OA\Property(property: 'versionInt', type: 'string'),
+        new OA\Property(property: 'langs', type: 'string', description: 'Comma-separated language codes.'),
+        new OA\Property(property: 'nativeLang', type: 'string'),
+        new OA\Property(property: 'centerLongitude', type: 'string'),
+        new OA\Property(property: 'centerLatitude', type: 'string'),
+        new OA\Property(property: 'centerZoom', type: 'string'),
+        new OA\Property(property: 'defaultDuration', type: 'string'),
+        new OA\Property(property: 'regionBias', type: 'string'),
+        new OA\Property(property: 'charSet', type: 'string'),
+        new OA\Property(property: 'distanceUnits', type: 'string', enum: ['mi', 'km']),
+        new OA\Property(property: 'semanticAdmin', type: 'string'),
+        new OA\Property(property: 'emailEnabled', type: 'string'),
+        new OA\Property(property: 'emailIncludesServiceBodies', type: 'string'),
+        new OA\Property(property: 'changesPerMeeting', type: 'string'),
+        new OA\Property(property: 'meeting_states_and_provinces', type: 'string'),
+        new OA\Property(property: 'meeting_counties_and_sub_provinces', type: 'string'),
+        new OA\Property(property: 'available_keys', type: 'string', description: 'Comma-separated list of field keys exposed by this server.'),
+        new OA\Property(property: 'google_api_key', type: 'string'),
+        new OA\Property(property: 'aggregator_mode_enabled', oneOf: [new OA\Schema(type: 'string'), new OA\Schema(type: 'boolean')], description: '`1` / `true` if this server is running in aggregator mode.'),
+    ]
+)]
+#[OA\Schema(
+    schema: 'SemanticError',
+    type: 'object',
+    additionalProperties: true,
+    properties: [
+        new OA\Property(property: 'error', type: 'string', description: 'Human-readable error message.'),
+    ]
+)]
+class Schemas extends Controller
+{
+}

--- a/src/app/Http/Controllers/Query/Swagger/ServerController.php
+++ b/src/app/Http/Controllers/Query/Swagger/ServerController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Query\Swagger;
+
+use OpenApi\Attributes as OA;
+
+class ServerController extends Controller
+{
+    #[OA\Get(
+        path: '/client_interface/json/?switcher=GetServerInfo',
+        operationId: 'getSemanticServerInfo',
+        summary: 'Get server information',
+        tags: ['Server'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: "Server metadata such as version, language, semantic admin URL, etc.",
+                content: new OA\JsonContent(type: 'array', items: new OA\Items(ref: '#/components/schemas/SemanticServerInfo'))
+            ),
+        ]
+    )]
+    public function getServerInfo()
+    {
+    }
+
+    #[OA\Get(
+        path: '/client_interface/json/?switcher=GetCoverageArea',
+        operationId: 'getCoverageArea',
+        summary: "Get the geographic coverage bounding box for this server",
+        tags: ['Server'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: "Bounding box for the area covered by this server's meetings",
+                content: new OA\JsonContent(
+                    type: 'object',
+                    properties: [
+                        new OA\Property(property: 'nw_corner_longitude', type: 'number', format: 'float'),
+                        new OA\Property(property: 'nw_corner_latitude', type: 'number', format: 'float'),
+                        new OA\Property(property: 'se_corner_longitude', type: 'number', format: 'float'),
+                        new OA\Property(property: 'se_corner_latitude', type: 'number', format: 'float'),
+                    ]
+                )
+            ),
+        ]
+    )]
+    public function getCoverageArea()
+    {
+    }
+}

--- a/src/app/Http/Controllers/Query/Swagger/ServiceBodiesController.php
+++ b/src/app/Http/Controllers/Query/Swagger/ServiceBodiesController.php
@@ -13,7 +13,6 @@ class ServiceBodiesController extends Controller
         tags: ['Service Bodies'],
         parameters: [
             new OA\Parameter(ref: '#/components/parameters/SemServices'),
-            new OA\Parameter(ref: '#/components/parameters/SemServicesArray'),
             new OA\Parameter(ref: '#/components/parameters/SemRecursive'),
             new OA\Parameter(name: 'parents', in: 'query', description: 'Set to `1` to include parent service bodies in the result.', schema: new OA\Schema(type: 'string', enum: ['0', '1'])),
         ],

--- a/src/app/Http/Controllers/Query/Swagger/ServiceBodiesController.php
+++ b/src/app/Http/Controllers/Query/Swagger/ServiceBodiesController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Query\Swagger;
+
+use OpenApi\Attributes as OA;
+
+class ServiceBodiesController extends Controller
+{
+    #[OA\Get(
+        path: '/client_interface/json/?switcher=GetServiceBodies',
+        operationId: 'getSemanticServiceBodies',
+        summary: 'Get service bodies',
+        tags: ['Service Bodies'],
+        parameters: [
+            new OA\Parameter(ref: '#/components/parameters/SemServices'),
+            new OA\Parameter(ref: '#/components/parameters/SemServicesArray'),
+            new OA\Parameter(ref: '#/components/parameters/SemRecursive'),
+            new OA\Parameter(name: 'parents', in: 'query', description: 'Set to `1` to include parent service bodies in the result.', schema: new OA\Schema(type: 'string', enum: ['0', '1'])),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'List of service bodies',
+                content: new OA\JsonContent(type: 'array', items: new OA\Items(ref: '#/components/schemas/SemanticServiceBody'))
+            ),
+        ]
+    )]
+    public function getServiceBodies()
+    {
+    }
+}

--- a/src/app/Http/Controllers/Query/SwaggerController.php
+++ b/src/app/Http/Controllers/Query/SwaggerController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Query;
+
+use App\Http\Controllers\Controller;
+use App\Http\Responses\JsonResponse;
+use Illuminate\Http\Request;
+
+class SwaggerController extends Controller
+{
+    public function openapi(Request $request)
+    {
+        $server = new \stdClass();
+        $server->url = rtrim(url('/'), '/') . '/';
+        $server->description = 'this server';
+
+        $json = json_decode(\File::get(storage_path('api-docs/api-docs-semantic.json')));
+        $json->servers = [$server];
+
+        return new JsonResponse($json);
+    }
+}

--- a/src/config/l5-swagger.php
+++ b/src/config/l5-swagger.php
@@ -43,6 +43,49 @@ return [
                 ],
 
             ],
+
+            'scanOptions' => [
+                'exclude' => [
+                    base_path('app/Http/Controllers/Query/Swagger'),
+                ],
+                'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+            ],
+        ],
+
+        'semantic' => [
+            'api' => [
+                'title' => 'BMLT Semantic API',
+            ],
+
+            'routes' => [
+                'api' => 'api/v1/documentation/semantic',
+                /*
+                 * Must differ from `default`'s docs route (which inherits the global
+                 * default `docs`) — otherwise the two documentations collide on the
+                 * same URL and only the last-registered one wins.
+                 */
+                'docs' => 'docs/semantic',
+                'oauth2_callback' => 'api/oauth2-callback-semantic',
+            ],
+
+            'paths' => [
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+                'docs_json' => 'api-docs-semantic.json',
+                'docs_yaml' => 'api-docs-semantic.yaml',
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Scope the scan to only the semantic stub classes so we don't pick up
+                 * the admin attributes (which live under app/Http/Controllers/Admin/Swagger).
+                 */
+                'annotations' => [
+                    base_path('app/Http/Controllers/Query/Swagger'),
+                ],
+            ],
+
+            'scanOptions' => [
+                'open_api_spec_version' => '3.1.0',
+            ],
         ],
     ],
     'defaults' => [

--- a/src/resources/views/vendor/l5-swagger/index.blade.php
+++ b/src/resources/views/vendor/l5-swagger/index.blade.php
@@ -126,7 +126,7 @@
         // Build a system
         const ui = SwaggerUIBundle({
             dom_id: '#swagger-ui',
-            url: "{{ route('openapi') }}",
+            url: "{{ route($documentation === 'semantic' ? 'openapi-semantic' : 'openapi') }}",
             operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
             configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
             validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Admin\ServiceBodyController;
 use App\Http\Controllers\Admin\TokenController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\Admin\SwaggerController;
+use App\Http\Controllers\Query\SwaggerController as SemanticSwaggerController;
 use App\Http\Controllers\Admin\LogController;
 use App\Http\Controllers\Admin\SettingController;
 use Illuminate\Support\Facades\Route;
@@ -25,6 +26,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/openapi.json', [SwaggerController::class, 'openapi'])->name('openapi');
+Route::get('/openapi-semantic.json', [SemanticSwaggerController::class, 'openapi'])->name('openapi-semantic');
 Route::post('/auth/token', [TokenController::class, 'token']);
 
 Route::apiResource('/rootservers', RootServerController::class, ['parameters' => ['rootservers' => 'rootServer']]);

--- a/src/storage/api-docs/api-docs-semantic.json
+++ b/src/storage/api-docs/api-docs-semantic.json
@@ -1,0 +1,1370 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "BMLT Semantic API",
+        "description": "OpenAPI description of the BMLT Semantic Interface (the read-only meeting-query API) for the JSON data format.\n\nThe semantic interface dispatches all operations from a single endpoint (`/client_interface/json/`) using a `switcher` query parameter. To keep each operation discoverable, this spec models each `switcher` value as a distinct path key with the query string baked in. Tools such as Swagger UI, Redoc, and openapi-generator handle these path keys correctly even though the OpenAPI spec technically expects unique URL paths.\n\n### Things that do not map cleanly onto OpenAPI\n\n- **PHP array syntax** — repeatable array parameters use trailing `[]` in the name (`weekdays[]=2&weekdays[]=3`).\n- **Sign-as-operator** — many filters (`formats`, `services`, `weekdays`, `venue_types`, `meeting_ids`, `root_server_ids`, `format_ids`) use *positive* values to include and *negative* values to exclude. JSON Schema cannot enforce that semantics; it is documented per parameter.\n- **Cross-parameter constraints** — in aggregator mode `GetSearchResults` requires at least one filter parameter. Invalid combinations typically return an empty array `[]` instead of an HTTP error.\n- **Empty-array errors** — many endpoints return `[]` for invalid input rather than a 4xx response body.",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "L5_SWAGGER_CONST_HOST",
+            "description": "this server"
+        }
+    ],
+    "paths": {
+        "/client_interface/json/?switcher=GetFieldKeys": {
+            "get": {
+                "tags": [
+                    "Fields"
+                ],
+                "summary": "Get all available field keys",
+                "operationId": "getFieldKeys",
+                "responses": {
+                    "200": {
+                        "description": "List of field key descriptors",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "key": {
+                                                "type": "string"
+                                            },
+                                            "description": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client_interface/json/?switcher=GetFieldValues": {
+            "get": {
+                "tags": [
+                    "Fields"
+                ],
+                "summary": "Get distinct values for a field",
+                "operationId": "getFieldValues",
+                "parameters": [
+                    {
+                        "name": "meeting_key",
+                        "in": "query",
+                        "description": "Field key whose distinct values should be returned.",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "location_municipality"
+                        }
+                    },
+                    {
+                        "name": "specific_formats",
+                        "in": "query",
+                        "description": "Comma-separated list of format IDs to limit the field values to.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "all_formats",
+                        "in": "query",
+                        "description": "Set to `1` to include all formats (not just `specific_formats`).",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "0",
+                                "1"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of distinct values with usage counts",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "ids": {
+                                                "type": "string"
+                                            },
+                                            "meeting_key_value": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/SemBadRequest"
+                    }
+                }
+            }
+        },
+        "/client_interface/json/?switcher=GetFormats": {
+            "get": {
+                "tags": [
+                    "Formats"
+                ],
+                "summary": "Get meeting formats",
+                "operationId": "getSemanticFormats",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/SemLangEnum"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemShowAll"
+                    },
+                    {
+                        "name": "format_ids",
+                        "in": "query",
+                        "description": "Format IDs to include (positive) or exclude (negative). Comma-separated.",
+                        "schema": {
+                            "type": "string",
+                            "example": "1,2,-3"
+                        }
+                    },
+                    {
+                        "name": "key_strings",
+                        "in": "query",
+                        "description": "Format key strings to filter by. Comma-separated.",
+                        "schema": {
+                            "type": "string",
+                            "example": "O,C"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of formats",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SemanticFormat"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client_interface/json/?switcher=GetSearchResults": {
+            "get": {
+                "tags": [
+                    "Meetings"
+                ],
+                "summary": "Search for meetings",
+                "description": "Search meetings with extensive filtering (location, day, time, format, service body, text). In aggregator mode at least one filter parameter is required, otherwise the response will be an empty array.",
+                "operationId": "getSearchResults",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/SemMeetingIds"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemMeetingIdsArray"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemWeekdays"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemWeekdaysArray"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemVenueTypes"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemVenueTypesArray"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemFormats"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemFormatsArray"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemFormatsComparisonOperator"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemServices"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemServicesArray"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemRecursive"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemGetUsedFormats"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemGetFormatsOnly"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemSearchString"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemStringSearchIsAnAddress"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemSearchStringRadius"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemStartsAfterH"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemStartsAfterM"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemStartsBeforeH"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemStartsBeforeM"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemEndsBeforeH"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemEndsBeforeM"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemMinDurationH"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemMinDurationM"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemMaxDurationH"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemMaxDurationM"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemLatVal"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemLongVal"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemGeoWidth"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemGeoWidthKm"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemSortResultsByDistance"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemMeetingKeyFilter"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemMeetingKeyValue"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemDataFieldKey"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemSortKeys"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemSortKey"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemPageSize"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemPageNum"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemAdvancedPublished"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemLangEnum"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemRootServerIds"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemRootServerIdsArray"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Meeting search results. May be a bare array of meetings, an array of formats when `get_formats_only=1`, or a `{meetings, formats}` envelope when `get_used_formats=1`.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/SemanticMeeting"
+                                            }
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/SemanticFormat"
+                                            }
+                                        },
+                                        {
+                                            "properties": {
+                                                "meetings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/SemanticMeeting"
+                                                    }
+                                                },
+                                                "formats": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/SemanticFormat"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/SemBadRequest"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/SemServerError"
+                    }
+                }
+            }
+        },
+        "/client_interface/json/?switcher=GetChanges": {
+            "get": {
+                "tags": [
+                    "Meetings"
+                ],
+                "summary": "Get meeting changes within a date range",
+                "operationId": "getChanges",
+                "parameters": [
+                    {
+                        "name": "start_date",
+                        "in": "query",
+                        "description": "Start date (inclusive) in YYYY-MM-DD format.",
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "end_date",
+                        "in": "query",
+                        "description": "End date (inclusive) in YYYY-MM-DD format.",
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "name": "meeting_id",
+                        "in": "query",
+                        "description": "Restrict to changes for a single meeting.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "service_body_id",
+                        "in": "query",
+                        "description": "Restrict to changes within a single service body.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of meeting changes",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SemanticMeetingChange"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client_interface/json/?switcher=GetServerInfo": {
+            "get": {
+                "tags": [
+                    "Server"
+                ],
+                "summary": "Get server information",
+                "operationId": "getSemanticServerInfo",
+                "responses": {
+                    "200": {
+                        "description": "Server metadata such as version, language, semantic admin URL, etc.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SemanticServerInfo"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client_interface/json/?switcher=GetCoverageArea": {
+            "get": {
+                "tags": [
+                    "Server"
+                ],
+                "summary": "Get the geographic coverage bounding box for this server",
+                "operationId": "getCoverageArea",
+                "responses": {
+                    "200": {
+                        "description": "Bounding box for the area covered by this server's meetings",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "nw_corner_longitude": {
+                                            "type": "number",
+                                            "format": "float"
+                                        },
+                                        "nw_corner_latitude": {
+                                            "type": "number",
+                                            "format": "float"
+                                        },
+                                        "se_corner_longitude": {
+                                            "type": "number",
+                                            "format": "float"
+                                        },
+                                        "se_corner_latitude": {
+                                            "type": "number",
+                                            "format": "float"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/client_interface/json/?switcher=GetServiceBodies": {
+            "get": {
+                "tags": [
+                    "Service Bodies"
+                ],
+                "summary": "Get service bodies",
+                "operationId": "getSemanticServiceBodies",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/SemServices"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemServicesArray"
+                    },
+                    {
+                        "$ref": "#/components/parameters/SemRecursive"
+                    },
+                    {
+                        "name": "parents",
+                        "in": "query",
+                        "description": "Set to `1` to include parent service bodies in the result.",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "0",
+                                "1"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of service bodies",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SemanticServiceBody"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "SemanticMeeting": {
+                "description": "A meeting record. The actual field set depends on the server's enabled fields and the `data_field_key` parameter.",
+                "properties": {
+                    "id_bigint": {
+                        "description": "Numeric meeting ID, returned as a string.",
+                        "type": "string"
+                    },
+                    "worldid_mixed": {
+                        "description": "NAWS world committee code.",
+                        "type": "string"
+                    },
+                    "shared_group_id_bigint": {
+                        "type": "string"
+                    },
+                    "service_body_bigint": {
+                        "type": "string"
+                    },
+                    "weekday_tinyint": {
+                        "description": "1=Sunday … 7=Saturday.",
+                        "type": "string"
+                    },
+                    "venue_type": {
+                        "description": "1=In-person, 2=Virtual, 3=Hybrid.",
+                        "type": "string"
+                    },
+                    "start_time": {
+                        "description": "Local start time, HH:MM:SS.",
+                        "type": "string"
+                    },
+                    "duration_time": {
+                        "description": "Duration, HH:MM:SS.",
+                        "type": "string"
+                    },
+                    "time_zone": {
+                        "type": "string"
+                    },
+                    "formats": {
+                        "description": "Comma-separated format key strings.",
+                        "type": "string"
+                    },
+                    "lang_enum": {
+                        "type": "string"
+                    },
+                    "longitude": {
+                        "type": "string"
+                    },
+                    "latitude": {
+                        "type": "string"
+                    },
+                    "distance_in_km": {
+                        "description": "Present only when sorting by distance.",
+                        "type": "string"
+                    },
+                    "distance_in_miles": {
+                        "description": "Present only when sorting by distance.",
+                        "type": "string"
+                    },
+                    "meeting_name": {
+                        "type": "string"
+                    },
+                    "location_text": {
+                        "type": "string"
+                    },
+                    "location_info": {
+                        "type": "string"
+                    },
+                    "location_street": {
+                        "type": "string"
+                    },
+                    "location_city_subsection": {
+                        "type": "string"
+                    },
+                    "location_neighborhood": {
+                        "type": "string"
+                    },
+                    "location_municipality": {
+                        "type": "string"
+                    },
+                    "location_sub_province": {
+                        "type": "string"
+                    },
+                    "location_province": {
+                        "type": "string"
+                    },
+                    "location_postal_code_1": {
+                        "type": "string"
+                    },
+                    "location_nation": {
+                        "type": "string"
+                    },
+                    "comments": {
+                        "type": "string"
+                    },
+                    "train_lines": {
+                        "type": "string"
+                    },
+                    "bus_lines": {
+                        "type": "string"
+                    },
+                    "phone_meeting_number": {
+                        "type": "string"
+                    },
+                    "virtual_meeting_link": {
+                        "type": "string"
+                    },
+                    "virtual_meeting_additional_info": {
+                        "type": "string"
+                    },
+                    "contact_name_1": {
+                        "type": "string"
+                    },
+                    "contact_phone_1": {
+                        "type": "string"
+                    },
+                    "contact_email_1": {
+                        "type": "string"
+                    },
+                    "root_server_id": {
+                        "description": "Aggregator mode only — ID of the root server this meeting came from.",
+                        "type": "string"
+                    },
+                    "root_server_uri": {
+                        "type": "string"
+                    },
+                    "format_shared_id_list": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": true
+            },
+            "SemanticFormat": {
+                "properties": {
+                    "key_string": {
+                        "type": "string"
+                    },
+                    "name_string": {
+                        "type": "string"
+                    },
+                    "description_string": {
+                        "type": "string"
+                    },
+                    "lang": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "world_id": {
+                        "type": "string"
+                    },
+                    "root_server_id": {
+                        "description": "Aggregator mode only.",
+                        "type": "string"
+                    },
+                    "root_server_uri": {
+                        "description": "Aggregator mode only.",
+                        "type": "string"
+                    },
+                    "format_type_enum": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": true
+            },
+            "SemanticServiceBody": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "parent_id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    },
+                    "helpline": {
+                        "type": "string"
+                    },
+                    "world_id": {
+                        "type": "string"
+                    },
+                    "root_server_id": {
+                        "description": "Aggregator mode only.",
+                        "type": "string"
+                    },
+                    "root_server_uri": {
+                        "description": "Aggregator mode only.",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": true
+            },
+            "SemanticMeetingChange": {
+                "properties": {
+                    "date_int": {
+                        "description": "Unix timestamp of the change.",
+                        "type": "string"
+                    },
+                    "date_string": {
+                        "type": "string"
+                    },
+                    "change_type": {
+                        "description": "e.g. comdef_change_type_change, comdef_change_type_new, comdef_change_type_delete.",
+                        "type": "string"
+                    },
+                    "meeting_id": {
+                        "type": "string"
+                    },
+                    "meeting_name": {
+                        "type": "string"
+                    },
+                    "user_id": {
+                        "type": "string"
+                    },
+                    "user_name": {
+                        "type": "string"
+                    },
+                    "service_body_id": {
+                        "type": "string"
+                    },
+                    "service_body_name": {
+                        "type": "string"
+                    },
+                    "details": {
+                        "description": "Per-field before/after values for change events.",
+                        "type": "object",
+                        "additionalProperties": true
+                    }
+                },
+                "type": "object",
+                "additionalProperties": true
+            },
+            "SemanticServerInfo": {
+                "properties": {
+                    "version": {
+                        "type": "string"
+                    },
+                    "versionInt": {
+                        "type": "string"
+                    },
+                    "langs": {
+                        "description": "Comma-separated language codes.",
+                        "type": "string"
+                    },
+                    "nativeLang": {
+                        "type": "string"
+                    },
+                    "centerLongitude": {
+                        "type": "string"
+                    },
+                    "centerLatitude": {
+                        "type": "string"
+                    },
+                    "centerZoom": {
+                        "type": "string"
+                    },
+                    "defaultDuration": {
+                        "type": "string"
+                    },
+                    "regionBias": {
+                        "type": "string"
+                    },
+                    "charSet": {
+                        "type": "string"
+                    },
+                    "distanceUnits": {
+                        "type": "string",
+                        "enum": [
+                            "mi",
+                            "km"
+                        ]
+                    },
+                    "semanticAdmin": {
+                        "type": "string"
+                    },
+                    "emailEnabled": {
+                        "type": "string"
+                    },
+                    "emailIncludesServiceBodies": {
+                        "type": "string"
+                    },
+                    "changesPerMeeting": {
+                        "type": "string"
+                    },
+                    "meeting_states_and_provinces": {
+                        "type": "string"
+                    },
+                    "meeting_counties_and_sub_provinces": {
+                        "type": "string"
+                    },
+                    "available_keys": {
+                        "description": "Comma-separated list of field keys exposed by this server.",
+                        "type": "string"
+                    },
+                    "google_api_key": {
+                        "type": "string"
+                    },
+                    "aggregator_mode_enabled": {
+                        "description": "`1` / `true` if this server is running in aggregator mode.",
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "boolean"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "additionalProperties": true
+            },
+            "SemanticError": {
+                "properties": {
+                    "error": {
+                        "description": "Human-readable error message.",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": true
+            }
+        },
+        "responses": {
+            "SemBadRequest": {
+                "description": "Bad request — usually a missing required parameter.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/SemanticError"
+                        }
+                    }
+                }
+            },
+            "SemServerError": {
+                "description": "Internal server error — for example, a geocoding failure when `StringSearchIsAnAddress=1`.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/SemanticError"
+                        }
+                    }
+                }
+            }
+        },
+        "parameters": {
+            "SemMeetingIds": {
+                "name": "meeting_ids",
+                "in": "query",
+                "description": "Comma-separated meeting IDs. Positive values include, negative values exclude (e.g. `123,456,-789`).",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "SemMeetingIdsArray": {
+                "name": "meeting_ids[]",
+                "in": "query",
+                "description": "Repeatable form of `meeting_ids`. Positive includes, negative excludes.",
+                "style": "form",
+                "explode": true,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "SemWeekdays": {
+                "name": "weekdays",
+                "in": "query",
+                "description": "Days of week as comma-separated values. 1=Sunday … 7=Saturday. Negative values exclude.",
+                "schema": {
+                    "type": "string",
+                    "example": "2,3,4"
+                }
+            },
+            "SemWeekdaysArray": {
+                "name": "weekdays[]",
+                "in": "query",
+                "description": "Repeatable form of `weekdays`. 1=Sunday … 7=Saturday. Negative values exclude.",
+                "style": "form",
+                "explode": true,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "maximum": 7,
+                        "minimum": -7
+                    }
+                }
+            },
+            "SemVenueTypes": {
+                "name": "venue_types",
+                "in": "query",
+                "description": "Venue type filter, comma-separated. 1=In-person, 2=Virtual, 3=Hybrid. Negative values exclude.",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "SemVenueTypesArray": {
+                "name": "venue_types[]",
+                "in": "query",
+                "description": "Repeatable form of `venue_types`. Negative values exclude.",
+                "style": "form",
+                "explode": true,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "enum": [
+                            -3,
+                            -2,
+                            -1,
+                            1,
+                            2,
+                            3
+                        ]
+                    }
+                }
+            },
+            "SemFormats": {
+                "name": "formats",
+                "in": "query",
+                "description": "Format IDs as comma-separated values. Positive includes, negative excludes.",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "SemFormatsArray": {
+                "name": "formats[]",
+                "in": "query",
+                "description": "Repeatable form of `formats`. Positive includes, negative excludes.",
+                "style": "form",
+                "explode": true,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "SemFormatsComparisonOperator": {
+                "name": "formats_comparison_operator",
+                "in": "query",
+                "description": "Logical operator for combining multiple `formats` values. Defaults to AND.",
+                "schema": {
+                    "type": "string",
+                    "default": "AND",
+                    "enum": [
+                        "AND",
+                        "OR"
+                    ]
+                }
+            },
+            "SemServices": {
+                "name": "services",
+                "in": "query",
+                "description": "Service body IDs as comma-separated values. Positive includes, negative excludes.",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "SemServicesArray": {
+                "name": "services[]",
+                "in": "query",
+                "description": "Repeatable form of `services`. Positive includes, negative excludes.",
+                "style": "form",
+                "explode": true,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "SemRecursive": {
+                "name": "recursive",
+                "in": "query",
+                "description": "Set to `1` to include child service bodies when filtering by `services`.",
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "0",
+                        "1"
+                    ]
+                }
+            },
+            "SemGetUsedFormats": {
+                "name": "get_used_formats",
+                "in": "query",
+                "description": "Set to `1` to also return the formats used by the matched meetings (alters response shape to `{meetings, formats}`).",
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "0",
+                        "1"
+                    ]
+                }
+            },
+            "SemGetFormatsOnly": {
+                "name": "get_formats_only",
+                "in": "query",
+                "description": "Set to `1` to return only the formats and omit the meetings (requires `get_used_formats=1`).",
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "0",
+                        "1"
+                    ]
+                }
+            },
+            "SemSearchString": {
+                "name": "SearchString",
+                "in": "query",
+                "description": "Free-text search string. URL-encode the value.",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "SemStringSearchIsAnAddress": {
+                "name": "StringSearchIsAnAddress",
+                "in": "query",
+                "description": "Set to `1` to interpret `SearchString` as an address to geocode. Requires a Google API key on the server.",
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "0",
+                        "1"
+                    ]
+                }
+            },
+            "SemSearchStringRadius": {
+                "name": "SearchStringRadius",
+                "in": "query",
+                "description": "Radius for address searches. Positive = distance (miles or km depending on server). Negative integer = auto-radius.",
+                "schema": {
+                    "type": "number"
+                }
+            },
+            "SemStartsAfterH": {
+                "name": "StartsAfterH",
+                "in": "query",
+                "description": "Earliest start hour (0–23).",
+                "schema": {
+                    "type": "integer",
+                    "maximum": 23,
+                    "minimum": 0
+                }
+            },
+            "SemStartsAfterM": {
+                "name": "StartsAfterM",
+                "in": "query",
+                "description": "Earliest start minute (0–59).",
+                "schema": {
+                    "type": "integer",
+                    "maximum": 59,
+                    "minimum": 0
+                }
+            },
+            "SemStartsBeforeH": {
+                "name": "StartsBeforeH",
+                "in": "query",
+                "description": "Latest start hour (0–23).",
+                "schema": {
+                    "type": "integer",
+                    "maximum": 23,
+                    "minimum": 0
+                }
+            },
+            "SemStartsBeforeM": {
+                "name": "StartsBeforeM",
+                "in": "query",
+                "description": "Latest start minute (0–59).",
+                "schema": {
+                    "type": "integer",
+                    "maximum": 59,
+                    "minimum": 0
+                }
+            },
+            "SemEndsBeforeH": {
+                "name": "EndsBeforeH",
+                "in": "query",
+                "description": "Latest end hour (0–23).",
+                "schema": {
+                    "type": "integer",
+                    "maximum": 23,
+                    "minimum": 0
+                }
+            },
+            "SemEndsBeforeM": {
+                "name": "EndsBeforeM",
+                "in": "query",
+                "description": "Latest end minute (0–59).",
+                "schema": {
+                    "type": "integer",
+                    "maximum": 59,
+                    "minimum": 0
+                }
+            },
+            "SemMinDurationH": {
+                "name": "MinDurationH",
+                "in": "query",
+                "description": "Minimum duration, hours portion.",
+                "schema": {
+                    "type": "integer",
+                    "minimum": 0
+                }
+            },
+            "SemMinDurationM": {
+                "name": "MinDurationM",
+                "in": "query",
+                "description": "Minimum duration, minutes portion (0–59).",
+                "schema": {
+                    "type": "integer",
+                    "maximum": 59,
+                    "minimum": 0
+                }
+            },
+            "SemMaxDurationH": {
+                "name": "MaxDurationH",
+                "in": "query",
+                "description": "Maximum duration, hours portion.",
+                "schema": {
+                    "type": "integer",
+                    "minimum": 0
+                }
+            },
+            "SemMaxDurationM": {
+                "name": "MaxDurationM",
+                "in": "query",
+                "description": "Maximum duration, minutes portion (0–59).",
+                "schema": {
+                    "type": "integer",
+                    "maximum": 59,
+                    "minimum": 0
+                }
+            },
+            "SemLatVal": {
+                "name": "lat_val",
+                "in": "query",
+                "description": "Latitude for geographic search.",
+                "schema": {
+                    "type": "number",
+                    "format": "float",
+                    "maximum": 90,
+                    "minimum": -90
+                }
+            },
+            "SemLongVal": {
+                "name": "long_val",
+                "in": "query",
+                "description": "Longitude for geographic search.",
+                "schema": {
+                    "type": "number",
+                    "format": "float",
+                    "maximum": 180,
+                    "minimum": -180
+                }
+            },
+            "SemGeoWidth": {
+                "name": "geo_width",
+                "in": "query",
+                "description": "Search radius in miles. Negative integer = auto-radius.",
+                "schema": {
+                    "type": "number"
+                }
+            },
+            "SemGeoWidthKm": {
+                "name": "geo_width_km",
+                "in": "query",
+                "description": "Search radius in kilometers. Negative integer = auto-radius.",
+                "schema": {
+                    "type": "number"
+                }
+            },
+            "SemSortResultsByDistance": {
+                "name": "sort_results_by_distance",
+                "in": "query",
+                "description": "Set to `1` to sort results by distance from `lat_val`/`long_val`.",
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "0",
+                        "1"
+                    ]
+                }
+            },
+            "SemMeetingKeyFilter": {
+                "name": "meeting_key",
+                "in": "query",
+                "description": "Field key to filter on (used with `meeting_key_value`).",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "SemMeetingKeyValue": {
+                "name": "meeting_key_value",
+                "in": "query",
+                "description": "Value to match against the field named by `meeting_key`.",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "SemDataFieldKey": {
+                "name": "data_field_key",
+                "in": "query",
+                "description": "Comma-separated list of fields to include in each returned meeting (whitelist).",
+                "schema": {
+                    "type": "string",
+                    "example": "id_bigint,meeting_name,weekday_tinyint,start_time"
+                }
+            },
+            "SemSortKeys": {
+                "name": "sort_keys",
+                "in": "query",
+                "description": "Comma-separated list of fields to sort by.",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "SemSortKey": {
+                "name": "sort_key",
+                "in": "query",
+                "description": "Predefined sort alias.",
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "weekday",
+                        "time",
+                        "town",
+                        "state",
+                        "weekday_state"
+                    ]
+                }
+            },
+            "SemPageSize": {
+                "name": "page_size",
+                "in": "query",
+                "description": "Number of results per page.",
+                "schema": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            },
+            "SemPageNum": {
+                "name": "page_num",
+                "in": "query",
+                "description": "Page number, 1-based. Only meaningful when `page_size` is set.",
+                "schema": {
+                    "type": "integer",
+                    "default": 1,
+                    "minimum": 1
+                }
+            },
+            "SemAdvancedPublished": {
+                "name": "advanced_published",
+                "in": "query",
+                "description": "Published-status filter. Omit to return only published meetings. `0` returns both. `-1` returns only unpublished (requires authentication).",
+                "schema": {
+                    "type": "integer",
+                    "enum": [
+                        -1,
+                        0
+                    ]
+                }
+            },
+            "SemLangEnum": {
+                "name": "lang_enum",
+                "in": "query",
+                "description": "Language code for translated format names (en, de, fr, es, it, pl, pt, sv, dk, fa).",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "SemShowAll": {
+                "name": "show_all",
+                "in": "query",
+                "description": "Set to `1` to include all formats (including ones not currently used by any meeting).",
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "0",
+                        "1"
+                    ]
+                }
+            },
+            "SemRootServerIds": {
+                "name": "root_server_ids",
+                "in": "query",
+                "description": "Aggregator mode only. Comma-separated root server IDs. Positive includes, negative excludes.",
+                "schema": {
+                    "type": "string"
+                }
+            },
+            "SemRootServerIdsArray": {
+                "name": "root_server_ids[]",
+                "in": "query",
+                "description": "Aggregator mode only. Repeatable form of `root_server_ids`. Positive includes, negative excludes.",
+                "style": "form",
+                "explode": true,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        }
+    },
+    "security": [],
+    "tags": [
+        {
+            "name": "Meetings",
+            "description": "Meeting search and change history"
+        },
+        {
+            "name": "Formats",
+            "description": "Meeting format metadata"
+        },
+        {
+            "name": "Service Bodies",
+            "description": "Service body (region/area) metadata"
+        },
+        {
+            "name": "Fields",
+            "description": "Schema introspection"
+        },
+        {
+            "name": "Server",
+            "description": "Server information and coverage"
+        }
+    ]
+}

--- a/src/storage/api-docs/api-docs-semantic.json
+++ b/src/storage/api-docs/api-docs-semantic.json
@@ -2,7 +2,7 @@
     "openapi": "3.1.0",
     "info": {
         "title": "BMLT Semantic API",
-        "description": "OpenAPI description of the BMLT Semantic Interface (the read-only meeting-query API) for the JSON data format.\n\nThe semantic interface dispatches all operations from a single endpoint (`/client_interface/json/`) using a `switcher` query parameter. To keep each operation discoverable, this spec models each `switcher` value as a distinct path key with the query string baked in. Tools such as Swagger UI, Redoc, and openapi-generator handle these path keys correctly even though the OpenAPI spec technically expects unique URL paths.\n\n### Things that do not map cleanly onto OpenAPI\n\n- **PHP array syntax** — repeatable array parameters use trailing `[]` in the name (`weekdays[]=2&weekdays[]=3`).\n- **Sign-as-operator** — many filters (`formats`, `services`, `weekdays`, `venue_types`, `meeting_ids`, `root_server_ids`, `format_ids`) use *positive* values to include and *negative* values to exclude. JSON Schema cannot enforce that semantics; it is documented per parameter.\n- **Cross-parameter constraints** — in aggregator mode `GetSearchResults` requires at least one filter parameter. Invalid combinations typically return an empty array `[]` instead of an HTTP error.\n- **Empty-array errors** — many endpoints return `[]` for invalid input rather than a 4xx response body.",
+        "description": "OpenAPI description of the BMLT Semantic Interface (the read-only meeting-query API) for the JSON data format.\n\nThe semantic interface dispatches all operations from a single endpoint (`/client_interface/json/`) using a `switcher` query parameter. To keep each operation discoverable, this spec models each `switcher` value as a distinct path key with the query string baked in. Tools such as Swagger UI, Redoc, and openapi-generator handle these path keys correctly even though the OpenAPI spec technically expects unique URL paths.\n\n### Things that do not map cleanly onto OpenAPI\n\n- **Sign-as-operator** — many filters (`formats`, `services`, `weekdays`, `venue_types`, `meeting_ids`, `root_server_ids`, `format_ids`) use *positive* values to include and *negative* values to exclude. JSON Schema cannot enforce that semantics; it is documented per parameter.\n- **Cross-parameter constraints** — in aggregator mode `GetSearchResults` requires at least one filter parameter. Invalid combinations typically return an empty array `[]` instead of an HTTP error.\n- **Empty-array errors** — many endpoints return `[]` for invalid input rather than a 4xx response body.",
         "version": "1.0.0"
     },
     "servers": [
@@ -174,34 +174,19 @@
                         "$ref": "#/components/parameters/SemMeetingIds"
                     },
                     {
-                        "$ref": "#/components/parameters/SemMeetingIdsArray"
-                    },
-                    {
                         "$ref": "#/components/parameters/SemWeekdays"
-                    },
-                    {
-                        "$ref": "#/components/parameters/SemWeekdaysArray"
                     },
                     {
                         "$ref": "#/components/parameters/SemVenueTypes"
                     },
                     {
-                        "$ref": "#/components/parameters/SemVenueTypesArray"
-                    },
-                    {
                         "$ref": "#/components/parameters/SemFormats"
-                    },
-                    {
-                        "$ref": "#/components/parameters/SemFormatsArray"
                     },
                     {
                         "$ref": "#/components/parameters/SemFormatsComparisonOperator"
                     },
                     {
                         "$ref": "#/components/parameters/SemServices"
-                    },
-                    {
-                        "$ref": "#/components/parameters/SemServicesArray"
                     },
                     {
                         "$ref": "#/components/parameters/SemRecursive"
@@ -295,9 +280,6 @@
                     },
                     {
                         "$ref": "#/components/parameters/SemRootServerIds"
-                    },
-                    {
-                        "$ref": "#/components/parameters/SemRootServerIdsArray"
                     }
                 ],
                 "responses": {
@@ -483,9 +465,6 @@
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/SemServices"
-                    },
-                    {
-                        "$ref": "#/components/parameters/SemServicesArray"
                     },
                     {
                         "$ref": "#/components/parameters/SemRecursive"
@@ -889,19 +868,6 @@
                     "type": "string"
                 }
             },
-            "SemMeetingIdsArray": {
-                "name": "meeting_ids[]",
-                "in": "query",
-                "description": "Repeatable form of `meeting_ids`. Positive includes, negative excludes.",
-                "style": "form",
-                "explode": true,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                }
-            },
             "SemWeekdays": {
                 "name": "weekdays",
                 "in": "query",
@@ -909,21 +875,6 @@
                 "schema": {
                     "type": "string",
                     "example": "2,3,4"
-                }
-            },
-            "SemWeekdaysArray": {
-                "name": "weekdays[]",
-                "in": "query",
-                "description": "Repeatable form of `weekdays`. 1=Sunday … 7=Saturday. Negative values exclude.",
-                "style": "form",
-                "explode": true,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer",
-                        "maximum": 7,
-                        "minimum": -7
-                    }
                 }
             },
             "SemVenueTypes": {
@@ -934,46 +885,12 @@
                     "type": "string"
                 }
             },
-            "SemVenueTypesArray": {
-                "name": "venue_types[]",
-                "in": "query",
-                "description": "Repeatable form of `venue_types`. Negative values exclude.",
-                "style": "form",
-                "explode": true,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer",
-                        "enum": [
-                            -3,
-                            -2,
-                            -1,
-                            1,
-                            2,
-                            3
-                        ]
-                    }
-                }
-            },
             "SemFormats": {
                 "name": "formats",
                 "in": "query",
                 "description": "Format IDs as comma-separated values. Positive includes, negative excludes.",
                 "schema": {
                     "type": "string"
-                }
-            },
-            "SemFormatsArray": {
-                "name": "formats[]",
-                "in": "query",
-                "description": "Repeatable form of `formats`. Positive includes, negative excludes.",
-                "style": "form",
-                "explode": true,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             },
             "SemFormatsComparisonOperator": {
@@ -995,19 +912,6 @@
                 "description": "Service body IDs as comma-separated values. Positive includes, negative excludes.",
                 "schema": {
                     "type": "string"
-                }
-            },
-            "SemServicesArray": {
-                "name": "services[]",
-                "in": "query",
-                "description": "Repeatable form of `services`. Positive includes, negative excludes.",
-                "style": "form",
-                "explode": true,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             },
             "SemRecursive": {
@@ -1327,19 +1231,6 @@
                 "description": "Aggregator mode only. Comma-separated root server IDs. Positive includes, negative excludes.",
                 "schema": {
                     "type": "string"
-                }
-            },
-            "SemRootServerIdsArray": {
-                "name": "root_server_ids[]",
-                "in": "query",
-                "description": "Aggregator mode only. Repeatable form of `root_server_ids`. Positive includes, negative excludes.",
-                "style": "form",
-                "explode": true,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 }
             }
         }


### PR DESCRIPTION
  No runtime behavior changes, adds documentation-only stubs and a new spec/UI route. The live semantic interface (`Query\SwitcherController`)  is untouched.
 
  - Add semantic interface annotations to app/Http/Controllers/Query/Swagger
  - Add `semantic` l5-swagger documentation, exclude from default scan
  - Expose JSON at `/api/v1/openapi-semantic.json`, UI at `/api/v1/documentation/semantic`
  - Update Makefile to generate both docs (--all)
  - Switch swagger UI view to load the correct spec per documentation