### PR TITLE
Pj/fix mysql fulltext search

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,19 +18,20 @@ jobs:
           - "8.4"
           - "8.5"
         db:
-          - "10.2"
-          - "latest"
+          - "mariadb:10.2"
+          - "mariadb:latest"
+          - "mysql:8.4"
     services:
-      mariadb:
-        image: mariadb:${{ matrix.db }}
+      db:
+        image: ${{ matrix.db }}
         ports:
           - 3306
         env:
-          MARIADB_USER: rootserver
-          MARIADB_PASSWORD: rootserver
-          MARIADB_DATABASE: rootserver
-          MARIADB_ROOT_PASSWORD: rootserver
-        options: --health-cmd="${{ (matrix.db == 'latest') && 'mariadb-admin' || 'mysqladmin' }} ping" --health-interval=5s --health-timeout=2s --health-retries=3
+          MYSQL_USER: rootserver
+          MYSQL_PASSWORD: rootserver
+          MYSQL_DATABASE: rootserver
+          MYSQL_ROOT_PASSWORD: rootserver
+        options: --health-cmd="${{ (matrix.db == 'mariadb:latest') && 'mariadb-admin' || 'mysqladmin' }} ping" --health-interval=5s --health-timeout=2s --health-retries=3
     steps:
       - name: checkout 🛒
         uses: actions/checkout@v6
@@ -52,12 +53,12 @@ jobs:
 
       - name: make test 🧪
         env:
-          DB_PORT: ${{ job.services.mariadb.ports[3306] }}
+          DB_PORT: ${{ job.services.db.ports[3306] }}
         run: |
           make test
 
       - name: Send coverage data to codecov.io 📀
-        if: matrix.db == 'latest' && matrix.php == '8.4'
+        if: matrix.db == 'mariadb:latest' && matrix.php == '8.4'
         uses: codecov/codecov-action@v5
         with:
           files: src/coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,19 +14,20 @@ jobs:
           - "8.4"
           - "8.5"
         db:
-          - "10.2"
-          - "latest"
+          - "mariadb:10.2"
+          - "mariadb:latest"
+          - "mysql:8.4"
     services:
-      mariadb:
-        image: mariadb:${{ matrix.db }}
+      db:
+        image: ${{ matrix.db }}
         ports:
           - 3306
         env:
-          MARIADB_USER: rootserver
-          MARIADB_PASSWORD: rootserver
-          MARIADB_DATABASE: rootserver
-          MARIADB_ROOT_PASSWORD: rootserver
-        options: --health-cmd="${{ (matrix.db == 'latest') && 'mariadb-admin' || 'mysqladmin' }} ping" --health-interval=5s --health-timeout=2s --health-retries=3
+          MYSQL_USER: rootserver
+          MYSQL_PASSWORD: rootserver
+          MYSQL_DATABASE: rootserver
+          MYSQL_ROOT_PASSWORD: rootserver
+        options: --health-cmd="${{ (matrix.db == 'mariadb:latest') && 'mariadb-admin' || 'mysqladmin' }} ping" --health-interval=5s --health-timeout=2s --health-retries=3
     steps:
       - name: checkout 🛒
         uses: actions/checkout@v6
@@ -48,7 +49,7 @@ jobs:
 
       - name: make test 🧪
         env:
-          DB_PORT: ${{ job.services.mariadb.ports[3306] }}
+          DB_PORT: ${{ job.services.db.ports[3306] }}
         run: |
           make test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.6 (August 3, 2026)
+* Fix meetings missing from text search results on servers running MySQL. Meetings sharing a name, location, or address with another meeting could be silently omitted while still being findable by ID, costing common searches 15-25% of their results. Searches are also considerably faster. MariaDB servers were not affected.
+
 ## 4.2.5 (July 31, 2026)
 * Fix `service_body_name` being dropped from `GetSearchResults` responses whenever `data_field_key` was used.
 

--- a/src/app/Repositories/MeetingRepository.php
+++ b/src/app/Repositories/MeetingRepository.php
@@ -204,14 +204,12 @@ class MeetingRepository implements MeetingRepositoryInterface
             }
 
             if (empty($moreMeetingIds)) {
+                // MySQL drops rows when MATCH() runs inside a correlated subquery, so keep these uncorrelated
+                // rather than using whereHas.
                 $meetings = $meetings->where(function (Builder $query) use ($searchString) {
                     $query
-                        ->whereHas('data', function (Builder $query) use ($searchString) {
-                            $query->whereFullText('data_string', $searchString);
-                        })
-                        ->orWhereHas('longdata', function (Builder $query) use ($searchString) {
-                            $query->whereFullText('data_blob', $searchString);
-                        });
+                        ->whereIn('id_bigint', MeetingData::query()->select('meetingid_bigint')->whereFullText('data_string', $searchString))
+                        ->orWhereIn('id_bigint', MeetingLongData::query()->select('meetingid_bigint')->whereFullText('data_blob', $searchString));
                 });
             } else {
                 $meetings = $meetings->whereIn('id_bigint', $moreMeetingIds);

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -28,7 +28,7 @@ return [
     | or any other location as required by the application or its packages.
     */
 
-    'version' => env('APP_VERSION', '4.2.5'),
+    'version' => env('APP_VERSION', '4.2.6'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/tests/Feature/GetSearchResultsTest.php
+++ b/src/tests/Feature/GetSearchResultsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\FromFileConfig;
 use App\Http\Resources\Query\MeetingResource;
 use App\FromDatabaseConfig;
+use App\Interfaces\MeetingRepositoryInterface;
 use App\Models\Format;
 use App\Models\Meeting;
 use App\Models\MeetingData;
@@ -1379,6 +1380,54 @@ class GetSearchResultsTest extends TestCase
                 MeetingData::query()->whereIn('meetingid_bigint', [$meeting1->id_bigint, $meeting2->id_bigint])->delete();
                 MeetingLongData::query()->whereIn('meetingid_bigint', [$meeting1->id_bigint, $meeting2->id_bigint])->delete();
             }
+        }
+    }
+
+    public function testSearchStringMatchesDuplicateValues()
+    {
+        // MySQL drops rows when MATCH() runs inside a correlated subquery, so meetings sharing an
+        // identical field value would go missing from the results. See issue #1519.
+        $meetingIds = [];
+        try {
+            for ($i = 0; $i < 3; $i++) {
+                $meeting = $this->createMeeting(dataFields: ['meeting_name' => 'this test is blah']);
+                $meetingIds[] = $meeting->id_bigint;
+            }
+            // MySQL full text searches do not work against uncommitted data, because the full text
+            // index has not yet been updated. We commit here, and then are very careful to clean up all
+            // data in the finally block
+            DB::commit();
+            $response = $this->get("/client_interface/json/?switcher=GetSearchResults&SearchString=blah%20test")
+                ->assertStatus(200)
+                ->assertJsonCount(3);
+            foreach ($meetingIds as $meetingId) {
+                $response->assertJsonFragment(['id_bigint' => strval($meetingId)]);
+            }
+        } finally {
+            Meeting::query()->whereIn('id_bigint', $meetingIds)->delete();
+            MeetingData::query()->whereIn('meetingid_bigint', $meetingIds)->delete();
+            MeetingLongData::query()->whereIn('meetingid_bigint', $meetingIds)->delete();
+        }
+    }
+
+    public function testSearchStringFullTextSubqueriesAreNotCorrelated()
+    {
+        // Whether MySQL actually drops rows depends on the query plan it picks, which varies with table
+        // statistics, so guard the query shape itself: the MATCH() subqueries must not reference the outer
+        // table. See issue #1519.
+        $queries = [];
+        DB::listen(function ($query) use (&$queries) {
+            $queries[] = $query->sql;
+        });
+        app(MeetingRepositoryInterface::class)->getSearchResults(searchString: 'blah test');
+
+        $fullTextQueries = array_values(array_filter($queries, fn($sql) => str_contains($sql, 'match')));
+        $this->assertNotEmpty($fullTextQueries);
+
+        foreach ($fullTextQueries as $sql) {
+            // strip the outer "select ... from `..._comdef_meetings_main`" so only the subqueries remain
+            $subqueries = substr($sql, strpos($sql, 'where'));
+            $this->assertStringNotContainsString('comdef_meetings_main', $subqueries);
         }
     }
 


### PR DESCRIPTION
## Summary

Text searches silently dropped meetings on MySQL. Searching "Recovery Has No Limits" returned only the Monday meeting (1204) and not the Friday one (1205), even though both exist and are individually retrievable by ID.

This was not a 4.2.5 regression — the rollback to 4.2.3 in the report didn't help because the bug predates both.

Fixes #1519

## Root cause

`MeetingRepository::getSearchResults` built the text search as two correlated `EXISTS` subqueries (`whereHas('data')->orWhereHas('longdata')`), each containing `MATCH() AGAINST()`.

MySQL plans that as a `DEPENDENT SUBQUERY` with `type: fulltext` / `Ft_hints: sorted`, and returns wrong results — the fulltext scan is re-evaluated per outer row and rows go missing. The tell, against the reporting server's data:

- query meeting 1205 alone → found
- query meeting 1204 alone → found
- query both together → **only 1204**

MariaDB executes the same plan correctly, so this was invisible to dev and CI, which run MariaDB only.

## Impact

Not one meeting — every text search on MySQL lost results. Against the reporting server's database on MySQL 8.4:

| search term | correct | returned | lost |
|---|---|---|---|
| Recovery Has No Limits | 81 | 69 | 15% |
| Church | 270 | 202 | 25% |
| Philadelphia | 216 | 159 | 26% |
| Street | 171 | 135 | 21% |
| New Beginnings | 80 | 61 | 24% |
| How It Works | 19 | 14 | 26% |

Every dropped meeting shared a field value with another meeting. Verified as pure false negatives — no wrong rows returned, just missing ones.

## Fix

Rewrite the two clauses as uncorrelated `whereIn` subqueries, so the fulltext scan runs once instead of once per candidate meeting.

Set-level comparison against ground truth on MySQL 8.4 ("Church"): truth 270, before 202, after 270 — exact match, no false positives, no false negatives. Holds under added filters (published, weekday, service body, `ORDER BY`/`LIMIT`).

Also ~20x faster on MySQL, since the correlated plan was the source of both problems:

| term | before | after |
|---|---|---|
| Church | 68.3 ms | 3.5 ms |
| Philadelphia | 121.1 ms | 4.0 ms |
| Street | 58.7 ms | 3.6 ms |

## MariaDB is unaffected

Identical results before and after on 10.2, 10.11, 11.4, 11.8 and 12.3, and identical timing (12.3: 80.4 ms → 80.1 ms). MariaDB's numbers already matched what MySQL now returns — the fix makes MySQL agree with MariaDB, it doesn't change MariaDB.

Also checked at 20x scale (10,140 meetings / 138,760 data rows): counts identical, timings within noise on both engines.

## Tests

- `testSearchStringMatchesDuplicateValues` — behavioural, meetings sharing a name all return.
- `testSearchStringFullTextSubqueriesAreNotCorrelated` — the real guard.

The shape assertion is deliberate. Whether MySQL actually drops rows depends on the plan it picks, which varies with table statistics — at test-suite scale it picks a semi-join and returns correct results, so a behavioural test can't reproduce this reliably, and wouldn't fail on MariaDB regardless. The shape test asserts the `MATCH()` subqueries don't reference the outer table; it fails without the fix on MariaDB, so it genuinely guards the regression in CI.

## CI

Added `mysql:8.4` to the test matrix alongside `mariadb:10.2` and `mariadb:latest` (6 → 9 jobs). The service block now takes a full image ref so one definition covers both engines; `MYSQL_*` env vars are accepted by both.


closes https://github.com/bmlt-enabled/bmlt-server/issues/1519